### PR TITLE
[feature] possible use prefix on redis client storage

### DIFF
--- a/Client/Driver/PredisDriver.php
+++ b/Client/Driver/PredisDriver.php
@@ -15,11 +15,18 @@ class PredisDriver implements DriverInterface
     protected $client;
 
     /**
-     * @param Client $client
+     * string $prefix
      */
-    public function __construct(Client $client)
+    protected $prefix;
+
+    /**
+     * @param Client $client
+     * @param string $prefix
+     */
+    public function __construct(Client $client, $prefix = '')
     {
         $this->client = $client;
+        $this->prefix = ($prefix !== false ? $prefix . ':' : '');
     }
 
     /**
@@ -27,7 +34,7 @@ class PredisDriver implements DriverInterface
      */
     public function fetch($id)
     {
-        $result = $this->client->get($id);
+        $result = $this->client->get($this->prefix . $id);
         if (null === $result) {
             return false;
         }
@@ -40,7 +47,7 @@ class PredisDriver implements DriverInterface
      */
     public function contains($id)
     {
-        return $this->client->exists($id);
+        return $this->client->exists($this->prefix . $id);
     }
 
     /**
@@ -49,9 +56,9 @@ class PredisDriver implements DriverInterface
     public function save($id, $data, $lifeTime = 0)
     {
         if ($lifeTime > 0) {
-            $response = $this->client->setex($id, $lifeTime, $data);
+            $response = $this->client->setex($this->prefix . $id, $lifeTime, $data);
         } else {
-            $response = $this->client->set($id, $data);
+            $response = $this->client->set($this->prefix . $id, $data);
         }
 
         return $response === true || $response == 'OK';
@@ -62,6 +69,6 @@ class PredisDriver implements DriverInterface
      */
     public function delete($id)
     {
-        return $this->client->del($id) > 0;
+        return $this->client->del($this->prefix . $id) > 0;
     }
 }

--- a/Client/Driver/PredisDriver.php
+++ b/Client/Driver/PredisDriver.php
@@ -26,7 +26,7 @@ class PredisDriver implements DriverInterface
     public function __construct(Client $client, $prefix = '')
     {
         $this->client = $client;
-        $this->prefix = ($prefix !== false ? $prefix . ':' : '');
+        $this->prefix = ($prefix !== '' ? $prefix . ':' : '');
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     const DEFAULT_TTL = 900;
+    const DEFAULT_PREFIX = false;
     const DEFAULT_CLIENT_STORAGE_SERVICE = '@gos_web_socket.server.in_memory.client_storage.driver';
     const DEFAULT_FIREWALL = 'ws_firewall';
     const DEFAULT_ORIGIN_CHECKER = false;
@@ -44,6 +45,10 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('ttl')
                                 ->defaultValue(static::DEFAULT_TTL)
                                 ->example(3600)
+                            ->end()
+                            ->scalarNode('prefix')
+                                ->defaultValue(static::DEFAULT_PREFIX)
+                                ->example('client')
                             ->end()
                             ->scalarNode('decorator')->end()
                         ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,7 +11,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     const DEFAULT_TTL = 900;
-    const DEFAULT_PREFIX = false;
+    const DEFAULT_PREFIX = '';
     const DEFAULT_CLIENT_STORAGE_SERVICE = '@gos_web_socket.server.in_memory.client_storage.driver';
     const DEFAULT_FIREWALL = 'ws_firewall';
     const DEFAULT_ORIGIN_CHECKER = false;

--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -52,6 +52,7 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
         }
 
         $container->setParameter('web_socket_server.client_storage.ttl', $configs['client']['storage']['ttl']);
+        $container->setParameter('web_socket_server.client_storage.prefix', $configs['client']['storage']['prefix']);
 
         if (isset($configs['client'])) {
             $clientConf = $configs['client'];

--- a/Resources/docs/SessionSetup.md
+++ b/Resources/docs/SessionSetup.md
@@ -71,6 +71,8 @@ gos_web_socket:
         session_handler: @session.handler.pdo
         storage:
             driver: @gos_web_scocket.client_storage.predis.driver
+            ttl: 28800 #(optionally) time to live if you use redis driver
+            prefix: client #(optionally) prefix if you use redis driver, create key "client:1" instead key "1"
 ```
 
 ### Doctrine Cache Bundle as Client Storage Driver
@@ -148,21 +150,26 @@ class PredisDriver implements DriverInterface
     protected $client;
 
     /**
-     * @param Client $client
+     * string $prefix
      */
-    public function __construct(Client $client)
+    protected $prefix;
+
+    /**
+     * @param Client $client
+     * @param string $prefix
+     */
+    public function __construct(Client $client, $prefix = '')
     {
         $this->client = $client;
+        $this->prefix = ($prefix !== false ? $prefix . ':' : '');
     }
 
     /**
-     * @param string $id
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
     public function fetch($id)
     {
-        $result = $this->client->get($id);
+        $result = $this->client->get($this->prefix . $id);
         if (null === $result) {
             return false;
         }
@@ -171,43 +178,33 @@ class PredisDriver implements DriverInterface
     }
 
     /**
-     * @param $id
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function contains($id)
     {
-        return $this->client->exists($id);
+        return $this->client->exists($this->prefix . $id);
     }
 
     /**
-     * @param string $id
-     * @param mixed  $data
-     * @param int    $lifeTime
-     *
-     * @return bool True if saved, false otherwise
+     * {@inheritdoc}
      */
     public function save($id, $data, $lifeTime = 0)
     {
         if ($lifeTime > 0) {
-            $response = $this->client->setex($id, $lifeTime, $data);
+            $response = $this->client->setex($this->prefix . $id, $lifeTime, $data);
         } else {
-            $response = $this->client->set($id, $data);
+            $response = $this->client->set($this->prefix . $id, $data);
         }
 
         return $response === true || $response == 'OK';
     }
 
     /**
-     * Deletes a cache entry.
-     *
-     * @param string $id The cache id.
-     *
-     * @return boolean TRUE if the cache entry was successfully deleted, FALSE otherwise.
+     * {@inheritdoc}
      */
     public function delete($id)
     {
-        return $this->client->del($id) > 0;
+        return $this->client->del($this->prefix . $id) > 0;
     }
 }
 ```

--- a/Resources/docs/SessionSetup.md
+++ b/Resources/docs/SessionSetup.md
@@ -217,6 +217,7 @@ services:
         class: Gos\Bundle\WebSocketBundle\Client\Driver\PredisDriver
         arguments:
             - @snc_redis.cache
+            - %web_socket_server.client_storage.prefix% #(optionally)if you use prefix
 ```
 
 **NOTE :** Predis driver class is included in GosWebSocketBundle, just register the service like below to use it.


### PR DESCRIPTION
I think that is useful feature, when use redis to storage client, can set prefix for key. For example instead key 1, exist key YOUR_PREFIX:1. I think it is a small duplication protection to keys from other parts of the application that uses redis, and increases transparency. 
![prefix](https://cloud.githubusercontent.com/assets/3453169/8985913/d6b745f8-36d9-11e5-90fa-e53700f02219.png)

Should not affect to the other storage, but please re-test it.