### PR TITLE
[Fix] AMQP_Connection doesn't accept key 'username' as configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -180,7 +180,7 @@ class Configuration implements ConfigurationInterface
                     ->isRequired()
                     ->cannotBeEmpty()
                 ->end()
-                ->scalarNode('username')
+                ->scalarNode('login')
                     ->isRequired()
                     ->cannotBeEmpty()
                 ->end()

--- a/Resources/docs/Pusher.md
+++ b/Resources/docs/Pusher.md
@@ -87,7 +87,7 @@ gos_web_socket:
         amqp:
             host: 127.0.0.1
             port: 5672
-            username: guest
+            login: guest
             password: guest
             vhost: '/'
 ```
@@ -158,7 +158,7 @@ Will give an `Gos\Bundle\WebSocketBundle\Event\PushHandlerEvent` where can acces
         amqp:
             host: 127.0.0.1
             port: 5672
-            username: guest
+            login: guest
             password: guest
 ```
 


### PR DESCRIPTION
The ``\AMQP_Connection`` object accepts an array with credentials, however the key used for username is defined as 'login'. (https://github.com/pdezwart/php-amqp/blob/master/amqp_connection.c#L267) This will not result in an error necessarily, but only when you configure an username other then 'guest'.

##### Changes
* Changed 'amqp' ``Configuration`` node 'username' to 'login'
* Modified Pusher documentation to match change in ``Configuration``