### PR TITLE
Symfony 2.7 is min requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/framework-bundle": "~2.3",
+        "symfony/framework-bundle": "~2.7",
         "gos/pubsub-router-bundle": "~0.1.0",
         "gos/websocket-client": "~0.1.0",
         "gos/ratchet-stack": "~0.1",


### PR DESCRIPTION
https://github.com/GeniusesOfSymfony/WebSocketBundle/blob/master/DependencyInjection/CompilerPass/DataCollectorCompilerPass.php#L33 doesn't exist in Symfony 2.3

```Call to undefined method Symfony\Component\DependencyInjection\Definition::setDecoratedService()```
