### PR TITLE
Periodic timer events do not cancel

### DIFF
--- a/Topic/TopicPeriodicTimer.php
+++ b/Topic/TopicPeriodicTimer.php
@@ -114,7 +114,7 @@ class TopicPeriodicTimer implements \IteratorAggregate
     {
         $namespace = spl_object_hash($topic);
 
-        if (isset($this->registry[$namespace][$name])) {
+        if (!isset($this->registry[$namespace][$name])) {
             return;
         }
 


### PR DESCRIPTION
Events in a `TopicPeriodicTimerInterface` object's `registerPeriodicTimer` method do not get cancelled at all because of this check being backward.  Short code snippet showing how I ran into it:

```php
if (!$this->periodicTimer->isPeriodicTimerActive($this, 'myEvent')) {
    // This only runs in certain conditions
    if ($conditionIsTrue) {
        $this->periodicTimer->addPeriodicTimer($this, 'myEvent', 15, function() use ($topic) {
            // Some condition to cancel the timer
            if ($shouldCancelTimer) {
                $this->periodicTimer->cancelPeriodicTimer($this, 'myEvent');
                return;
            }

            // Other code that runs if we don't cancel the event
        });
    }
}
```