### PR TITLE
SF3 : Fix dependency and services contructor

### DIFF
--- a/DependencyInjection/CompilerPass/LoopFactoryCompilerPass.php
+++ b/DependencyInjection/CompilerPass/LoopFactoryCompilerPass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class LoopFactoryCompilerPass
+ *
+ * @package Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass
+ */
+class LoopFactoryCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition('gos_web_socket.server.event_loop');
+
+        if (method_exists($definition, 'setFactory')) {
+            $definition->setFactory('React\EventLoop\Factory::create');
+        } else {
+            // SF < 2.6
+            $definition
+                ->setFactoryClass('React\EventLoop\Factory')
+                ->setFactoryMethod('create');
+        }
+    }
+}

--- a/GosWebSocketBundle.php
+++ b/GosWebSocketBundle.php
@@ -3,7 +3,6 @@
 namespace Gos\Bundle\WebSocketBundle;
 
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\DataCollectorCompilerPass;
-use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\LoopCompilerPass;
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\LoopFactoryCompilerPass;
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\PeriodicCompilerPass;
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\PingableDriverCompilerPass;

--- a/GosWebSocketBundle.php
+++ b/GosWebSocketBundle.php
@@ -3,6 +3,8 @@
 namespace Gos\Bundle\WebSocketBundle;
 
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\DataCollectorCompilerPass;
+use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\LoopCompilerPass;
+use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\LoopFactoryCompilerPass;
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\PeriodicCompilerPass;
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\PingableDriverCompilerPass;
 use Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass\PusherCompilerPass;
@@ -30,6 +32,7 @@ class GosWebSocketBundle extends Bundle
             ->addCompilerPass(new PingableDriverCompilerPass())
             ->addCompilerPass(new PusherCompilerPass())
             ->addCompilerPass(new DataCollectorCompilerPass())
+            ->addCompilerPass(new LoopFactoryCompilerPass())
         ;
     }
 }

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -161,8 +161,7 @@ services:
 
     gos_web_socket.server.event_loop:
         class: React\EventLoop\Factory
-        factory_class: React\EventLoop\Factory
-        factory_method: create
+        factory: ['React\EventLoop\Factory', 'create']
 
     gos_web_socket.topic.periodic_timer:
         class: Gos\Bundle\WebSocketBundle\Topic\TopicPeriodicTimer

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -161,7 +161,6 @@ services:
 
     gos_web_socket.server.event_loop:
         class: React\EventLoop\Factory
-        factory: ['React\EventLoop\Factory', 'create']
 
     gos_web_socket.topic.periodic_timer:
         class: Gos\Bundle\WebSocketBundle\Topic\TopicPeriodicTimer

--- a/Server/Type/WebSocketServer.php
+++ b/Server/Type/WebSocketServer.php
@@ -71,7 +71,7 @@ class WebSocketServer implements ServerInterface
     protected $topicManager;
 
     /**
-     * @param Factory                  $loop
+     * @param LoopInterface            $loop
      * @param EventDispatcherInterface $eventDispatcher
      * @param PeriodicRegistry         $periodicRegistry
      * @param WampApplication          $wampApplication
@@ -81,7 +81,7 @@ class WebSocketServer implements ServerInterface
      * @param LoggerInterface|null     $logger
      */
     public function __construct(
-        Factory $loop,
+        LoopInterface $loop,
         EventDispatcherInterface $eventDispatcher,
         PeriodicRegistry $periodicRegistry,
         WampApplication $wampApplication,
@@ -91,7 +91,7 @@ class WebSocketServer implements ServerInterface
         ServerPushHandlerRegistry $serverPushHandlerRegistry,
         LoggerInterface $logger = null
     ) {
-        $this->loop = $loop->create();
+        $this->loop = $loop;
         $this->eventDispatcher = $eventDispatcher;
         $this->periodicRegistry = $periodicRegistry;
         $this->wampApplication = $wampApplication;

--- a/Server/Type/WebSocketServer.php
+++ b/Server/Type/WebSocketServer.php
@@ -15,6 +15,7 @@ use ProxyManager\Proxy\ProxyInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Ratchet\Wamp\TopicManager;
+use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
 use React\Socket\Server;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -70,7 +71,7 @@ class WebSocketServer implements ServerInterface
     protected $topicManager;
 
     /**
-     * @param LoopInterface            $loop
+     * @param Factory                  $loop
      * @param EventDispatcherInterface $eventDispatcher
      * @param PeriodicRegistry         $periodicRegistry
      * @param WampApplication          $wampApplication
@@ -80,7 +81,7 @@ class WebSocketServer implements ServerInterface
      * @param LoggerInterface|null     $logger
      */
     public function __construct(
-        LoopInterface $loop,
+        Factory $loop,
         EventDispatcherInterface $eventDispatcher,
         PeriodicRegistry $periodicRegistry,
         WampApplication $wampApplication,
@@ -90,7 +91,7 @@ class WebSocketServer implements ServerInterface
         ServerPushHandlerRegistry $serverPushHandlerRegistry,
         LoggerInterface $logger = null
     ) {
-        $this->loop = $loop;
+        $this->loop = $loop->create();
         $this->eventDispatcher = $eventDispatcher;
         $this->periodicRegistry = $periodicRegistry;
         $this->wampApplication = $wampApplication;

--- a/Topic/TopicPeriodicTimer.php
+++ b/Topic/TopicPeriodicTimer.php
@@ -20,11 +20,11 @@ class TopicPeriodicTimer implements \IteratorAggregate
 
     /**
      * @param ConnectionInterface $connection
-     * @param Factory             $loop
+     * @param LoopInterface       $loop
      */
-    public function __construct(Factory $loop)
+    public function __construct(LoopInterface $loop)
     {
-        $this->loop = $loop->create();
+        $this->loop = $loop;
         $this->registry = [];
     }
 

--- a/Topic/TopicPeriodicTimer.php
+++ b/Topic/TopicPeriodicTimer.php
@@ -3,6 +3,7 @@
 namespace Gos\Bundle\WebSocketBundle\Topic;
 
 use Ratchet\ConnectionInterface;
+use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
 
 class TopicPeriodicTimer implements \IteratorAggregate
@@ -19,11 +20,11 @@ class TopicPeriodicTimer implements \IteratorAggregate
 
     /**
      * @param ConnectionInterface $connection
-     * @param LoopInterface       $loop
+     * @param Factory             $loop
      */
-    public function __construct(LoopInterface $loop)
+    public function __construct(Factory $loop)
     {
-        $this->loop = $loop;
+        $this->loop = $loop->create();
         $this->registry = [];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "php": ">=5.4",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "gos/pubsub-router-bundle": "~0.1.0",
+        "gos/pubsub-router-bundle": "dev-sf3",
         "gos/websocket-client": "~0.1.0",
         "gos/ratchet-stack": "~0.1",
         "gos/pnctl-event-loop-emitter" : "~0.1",
-        "gos/ratchet": "~0.3.0"
+        "gos/ratchet": "~0.3.5"
     },
     "replace" : {
         "cboden/ratchet": "~0.3.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "gos/pubsub-router-bundle": "dev-sf3",
+        "gos/pubsub-router-bundle": "~0.1.0|dev-sf3",
         "gos/websocket-client": "~0.1.0",
         "gos/ratchet-stack": "~0.1",
         "gos/pnctl-event-loop-emitter" : "~0.1",


### PR DESCRIPTION
It works with Symfony `^3.0` but I don't really like this line in composer file : 
`"gos/pubsub-router-bundle": "dev-sf3"`
Maybe create a branch-alias in [gos/pubsub-router-bundle](https://github.com/GeniusesOfSymfony/PubSubRouterBundle/tree/sf3) or a tag version.

