### PR TITLE
Don't need to inject Serializer twice

### DIFF
--- a/Pusher/Wamp/WampPusher.php
+++ b/Pusher/Wamp/WampPusher.php
@@ -3,22 +3,10 @@
 namespace Gos\Bundle\WebSocketBundle\Pusher\Wamp;
 
 use Gos\Bundle\WebSocketBundle\Pusher\AbstractPusher;
-use Gos\Bundle\WebSocketBundle\Pusher\Serializer\MessageSerializer;
 use Gos\Component\WebSocketClient\Wamp\Client;
 
 class WampPusher extends AbstractPusher
 {
-    /** @var  MessageSerializer */
-    protected $serializer;
-
-    /**
-     * @param MessageSerializer $serializer
-     */
-    public function __construct(MessageSerializer $serializer)
-    {
-        $this->serializer = $serializer;
-    }
-
     /**
      * @param string $data
      * @param array  $context

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -213,8 +213,6 @@ services:
     gos_web_socket.wamp.pusher:
         parent: gos_web_socket.abstract.pusher
         class: Gos\Bundle\WebSocketBundle\Pusher\Wamp\WampPusher
-        arguments:
-            - '@gos_web_socket.push_message.serializer'
         tags:
             - { name: gos_web_socket.pusher, alias: wamp }
 


### PR DESCRIPTION
In the WAMP pusher, the `@gos_web_socket.push_message.serializer` service gets injected through both the constructor and a method call defined by the parent `@gos_web_socket.abstract.pusher` service.  The constructor injection is therefore duplicated code and can be removed.