### PR TITLE
Allow to change the token separator from the configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,6 +15,7 @@ class Configuration implements ConfigurationInterface
     const DEFAULT_CLIENT_STORAGE_SERVICE = '@gos_web_socket.server.in_memory.client_storage.driver';
     const DEFAULT_FIREWALL = 'ws_firewall';
     const DEFAULT_ORIGIN_CHECKER = false;
+    const DEFAULT_TOKEN_SEPARATOR = '/';
 
     /**
      * {@inheritdoc}
@@ -82,6 +83,14 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('resources')
                                 ->prototype('scalar')
                                     ->example('@GosNotificationBundle/Resources/config/pubsub/websocket/notification.yml')
+                                ->end()
+                            ->end()
+                            ->arrayNode('context')
+                                ->children()
+                                    ->variableNode('tokenSeparator')
+                                        ->example('/')
+                                        ->defaultValue(static::DEFAULT_TOKEN_SEPARATOR)
+                                    ->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -173,7 +173,7 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
 
         if (!empty($pubsubConfig)) {
             if (!isset($pubsubConfig['context']['tokenSeparator'])) {
-                $pubsubConfig['context']['tokenSeparator'] = '/';
+                $pubsubConfig['context']['tokenSeparator'] = Configuration::DEFAULT_TOKEN_SEPARATOR;
             }
 
             $container->prependExtensionConfig('gos_pubsub_router', [

--- a/Resources/docs/ConfigurationReference.md
+++ b/Resources/docs/ConfigurationReference.md
@@ -17,6 +17,8 @@ gos_web_socket:
         router:
             resources:
                 - @AcmeBundle/Resources/config/pubsub/routing.yml
+            context:
+                tokenSeparator: "/"
     rpc:                  []
     topics:               []
     periodic:             []

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Gos\Bundle\WebSocketBundle\Tests;
+
+use Gos\Bundle\WebSocketBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * Class ConfigurationTest
+ */
+final class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testContextConfigurationIsOptional()
+    {
+        /* Config:
+         *
+         * server:
+         *   host: "127.0.0.1"
+         *   port: "8080"
+         */
+        $configs = array(
+            array(
+                'server' => array(
+                    'host' => "127.0.0.1",
+                    'port' => "8080",
+                ),
+            ),
+        );
+
+        $config = $this->process($configs);
+
+        $this->assertEquals('127.0.0.1', $config['server']['host']);
+        $this->assertEquals('8080', $config['server']['port']);
+    }
+
+    /**
+     * Processes an array of configurations and returns a compiled version.
+     *
+     * @param array $configs An array of raw configurations
+     *
+     * @return array A normalized array
+     */
+    protected function process($configs)
+    {
+        $processor = new Processor();
+
+        return $processor->processConfiguration(new Configuration(), $configs);
+    }
+
+    public function testTokenSeparatorIsSet()
+    {
+        /*
+         * Config:
+         *
+         * server:
+         *   host: "127.0.0.1"
+         *   port: "8080"
+         *   router:
+         *     context:
+         *       tokenSeparator: "-"
+         */
+        $configs = array(
+            array(
+                'server' => array(
+                    'host' => "127.0.0.1",
+                    'port' => "8080",
+                    'router' => array(
+                        'context' => array(
+                            "tokenSeparator" => "/",
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $config = $this->process($configs);
+
+        $this->assertEquals(
+            '/',
+            $config['server']['router']['context']['tokenSeparator']
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
         "gos/pnctl-event-loop-emitter" : "~0.1",
         "gos/ratchet": "~0.3.5"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
+    },
     "replace" : {
         "cboden/ratchet": "~0.3.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="WebSocketBundle for the Symfony Framework">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Hello

In my case I use the "-" character for token separator. This PR allow to choose another token separator than the default "/". The slash remain the default separator. This parameter is optional.