### PR TITLE
Undefined variable siginfo, spelling fixes

### DIFF
--- a/Event/StartServerListener.php
+++ b/Event/StartServerListener.php
@@ -90,12 +90,14 @@ class StartServerListener
 
         $pnctlEmitter->on(SIGINT, function () use ($pnctlEmitter) {
 
-            $this->logger->notice('Press CTLR+C again to stop the server');
+            $this->logger->notice('Press CTRL+C again to stop the server');
+
+            $siginfo = [];
 
             if (SIGINT === pcntl_sigtimedwait([SIGINT], $siginfo, 5)) {
                 $pnctlEmitter->emit(SIGTERM);
             } else {
-                $this->logger->notice('CTLR+C not pressed, continue to run normally');
+                $this->logger->notice('CTRL+C not pressed, continue to run normally');
             }
         });
     }


### PR DESCRIPTION
The `$siginfo` variable is currently undefined, pressing `CTRL-C` causes a notice in the console for this.

Also corrected the spelling of CTRL.