### PR TITLE
Typehint the Doctrine Cache interface instead of the CacheProvider class

### DIFF
--- a/Client/Driver/DoctrineCacheDriverDecorator.php
+++ b/Client/Driver/DoctrineCacheDriverDecorator.php
@@ -2,7 +2,7 @@
 
 namespace Gos\Bundle\WebSocketBundle\Client\Driver;
 
-use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Cache;
 
 /**
  * @author Johann Saunier <johann_27@hotmail.fr>
@@ -10,14 +10,14 @@ use Doctrine\Common\Cache\CacheProvider;
 class DoctrineCacheDriverDecorator implements DriverInterface
 {
     /**
-     * @var CacheProvider
+     * @var Cache
      */
     protected $cacheProvider;
 
     /**
-     * @param CacheProvider $cacheProvider
+     * @param Cache $cacheProvider
      */
-    public function __construct(CacheProvider $cacheProvider)
+    public function __construct(Cache $cacheProvider)
     {
         $this->cacheProvider = $cacheProvider;
     }


### PR DESCRIPTION
Allow any object implementing Doctrine's `Cache` interface instead of restricting to classes extending the abstract `CacheProvider`.