### PR TITLE
try to find alias to fix "Class not found"

### DIFF
--- a/DependencyInjection/CompilerPass/PingableDriverCompilerPass.php
+++ b/DependencyInjection/CompilerPass/PingableDriverCompilerPass.php
@@ -15,7 +15,7 @@ class PingableDriverCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $sessionHandler = $container->get('gos_web_socket.session_handler', Container::NULL_ON_INVALID_REFERENCE);
+        $sessionHandler = $container->getAlias('gos_web_socket.session_handler', Container::NULL_ON_INVALID_REFERENCE);
 
         if (null === $sessionHandler || false === $sessionHandler instanceof PdoSessionHandler) {
             return;


### PR DESCRIPTION
Tested on Symfony 2.8+

When a ``session_handler`` is configured, the ``PingableDriverCompilerPass`` try to get the service alias ``gos_web_socket.session_handler``. It returns the error ``ReflectionException in ContainerBuilder.php line 929: Class does not exist``.

The fix replaces ``get()`` by ``getAlias``, and works.

Also fix #134 