### PR TITLE
make compatible with php 7.1

### DIFF
--- a/Server/App/Dispatcher/TopicDispatcherInterface.php
+++ b/Server/App/Dispatcher/TopicDispatcherInterface.php
@@ -50,5 +50,5 @@ interface TopicDispatcherInterface
      *
      * @return bool
      */
-    public function dispatch($calledMethod, ConnectionInterface $conn = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null);
+    public function dispatch($calledMethod, ConnectionInterface $conn, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null);
 }


### PR DESCRIPTION
Fixes this:
PHP Fatal error:  Declaration of GosBundleWebSocketBundleServerAppDispatcherTopicDispatcher_000000003523c6a7000000005918c023030ddf746fbe22dfac87e52212494d92::dispatch($calledMethod, Ratchet\ConnectionInterface $conn,  
   Ratchet\Wamp\Topic $topic, Gos\Bundle\WebSocketBundle\Router\WampRequest $request, $payload = NULL, $exclude = NULL, $eligible = NULL, $provider = NULL) must be compatible with Gos\Bundle\WebSocketBundle\Server\App\  
  Dispatcher\TopicDispatcherInterface::dispatch($calledMethod, ?Ratchet\ConnectionInterface $conn, Ratchet\Wamp\Topic $topic, Gos\Bundle\WebSocketBundle\Router\WampRequest $request, $payload = NULL, $exclude = NULL, $e  
  ligible = NULL)