### PR TITLE
Allow to use a parameter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -154,7 +154,7 @@ class Configuration implements ConfigurationInterface
                     ->isRequired()
                     ->cannotBeEmpty()
                 ->end()
-                ->booleanNode('ssl')
+                ->scalarNode('ssl')
                     ->defaultValue(false)
                 ->end()
                 ->scalarNode('origin')

--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -160,7 +160,7 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
             if (!is_bool($configs['pushers']['wamp']['ssl'])) {
                 throw new \InvalidArgumentException(sprintf('The ssl node under wamp pusher configuration must be a boolean value'));
             }
-        }        
+        }
     }
 
     /**

--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -154,6 +154,13 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
             $container->getDefinition('gos_web_socket.router.wamp')
                 ->replaceArgument(0, new Reference('gos_pubsub_router.websocket'));
         }
+        
+        // WAMP Pusher Configuration
+        if (isset($configs['pushers']) && isset($configs['pushers']['wamp'])) {
+            if (!is_bool($configs['pushers']['wamp']['ssl'])) {
+                throw new \InvalidArgumentException(sprintf('The ssl node under wamp pusher configuration must be a boolean value'));
+            }
+        }        
     }
 
     /**


### PR DESCRIPTION
Imho, it's more relevant to set a scalar node instead of a boolean node because it allows us to put a DIC parameter.
Indeed, the ssl should depend on the environment, and for this value, we would not override it in another configuration file.