### PR TITLE
Added firewalled topic

### DIFF
--- a/Resources/docs/TopicSetup.md
+++ b/Resources/docs/TopicSetup.md
@@ -152,6 +152,64 @@ Where
 * `TopicInterface $topic` is the [Topic object](http://socketo.me/api/class-Ratchet.Wamp.Topic.html). This also contains a list of current subscribers, so you don't have to manually keep track.
 * `WampRequest` Is the representation of the request make trough websocket.
 
+### Firewall setup (Topic)
+
+It is possible to extend basic functionality of Topic Services to exclude unwanted connections.
+You must implement `FirewalledTopicInterface` to implement firewall functinoality into your `Topic` object.
+
+FirewalledTopicInterface requires your `Topic` to implement one additional function:
+
+* `checkConnection(ConnectionInterface $connection = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null)`
+
+Possible return values are:
+
+* `$error` [string]: the connection is rejected for the reason $error
+* `null` : the connection is granted
+
+A possible implementation is the following:
+
+```php
+<?php
+
+namespace Acme\HomeBundle\Topics;
+
+use Gos\Bundle\WebSocketBundle\Topic\TopicInterface;
+use Gos\Bundle\WebSocketBundle\Router\WampRequest;
+use Gos\Bundle\WebSocketBundle\Topic\FirewalledTopicInterface;
+use Ratchet\ConnectionInterface;
+use Ratchet\Wamp\Topic;
+
+class AcmeFirewalledTopic implements TopicInterface, FirewalledTopicInterface
+{
+    /**
+     * @param ConnectionInterface $conn
+     * @param Topic               $topic
+     * @param null|string         $payload
+     * @param string[]|null       $exclude
+     * @param string[]|null       $eligible
+     * @param string|null         $provider
+     *
+     * @return string|null        $error
+     */
+    public function checkConnection(ConnectionInterface $connection = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null)
+    {
+        // check input data to verify if connection must be blocked
+        if ( /* ... */ )
+        {
+            // return error string to deny access
+            return 'Unauhtorized';
+        }
+        else
+        {
+            // return null to grant access
+            return null;
+        }
+    }
+}
+
+```
+
+
 ### Periodic Timer (Topic & Connection)
 
 Topic periodic timer are active when at least one client is connected.

--- a/Resources/docs/TopicSetup.md
+++ b/Resources/docs/TopicSetup.md
@@ -155,16 +155,13 @@ Where
 ### Firewall setup (Topic)
 
 It is possible to extend basic functionality of Topic Services to exclude unwanted connections.
-You must implement `FirewalledTopicInterface` to implement firewall functinoality into your `Topic` object.
+You must implement `SecuredTopicInterface` to implement firewall functionality into your `Topic` object.
 
-FirewalledTopicInterface requires your `Topic` to implement one additional function:
+SecuredTopicInterface requires your `Topic` to implement one additional function:
 
-* `checkConnection(ConnectionInterface $connection = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null)`
+* `secure(ConnectionInterface $connection = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null)`
 
-Possible return values are:
-
-* `$error` [string]: the connection is rejected for the reason $error
-* `null` : the connection is granted
+It must throw an exception (instance of `FirewallRejectionException`) if connection security check fails.
 
 A possible implementation is the following:
 
@@ -175,11 +172,12 @@ namespace Acme\HomeBundle\Topics;
 
 use Gos\Bundle\WebSocketBundle\Topic\TopicInterface;
 use Gos\Bundle\WebSocketBundle\Router\WampRequest;
-use Gos\Bundle\WebSocketBundle\Topic\FirewalledTopicInterface;
+use Gos\Bundle\WebSocketBundle\Topic\SecuredTopicInterface;
+use Gos\Bundle\WebSocketBundle\Server\Exception\FirewallRejectionException;
 use Ratchet\ConnectionInterface;
 use Ratchet\Wamp\Topic;
 
-class AcmeFirewalledTopic implements TopicInterface, FirewalledTopicInterface
+class AcmeSecuredTopic implements TopicInterface, SecuredTopicInterface
 {
     /**
      * @param ConnectionInterface $conn
@@ -191,18 +189,13 @@ class AcmeFirewalledTopic implements TopicInterface, FirewalledTopicInterface
      *
      * @return string|null        $error
      */
-    public function checkConnection(ConnectionInterface $connection = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null)
+    public function secure(ConnectionInterface $connection = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null)
     {
         // check input data to verify if connection must be blocked
-        if ( /* ... */ )
-        {
-            // return error string to deny access
-            return 'Unauhtorized';
-        }
-        else
-        {
-            // return null to grant access
-            return null;
+        if ( /* ... */ ) {
+            throw new FirewallRejectionException();
+        } else {
+            // grant access
         }
     }
 }

--- a/Server/App/Dispatcher/TopicDispatcher.php
+++ b/Server/App/Dispatcher/TopicDispatcher.php
@@ -140,11 +140,10 @@ class TopicDispatcher implements TopicDispatcherInterface
                 $appTopic = $this->topicRegistry->getTopic($callback);
 
                 if ($appTopic instanceof SecuredTopicInterface) {
-
                     try {
-                        $appTopic->secure($conn, $topic, $request, $payload , $exclude , $eligible , $provider);
-                    } catch ( FirewallRejectionException $e ) {
-                        $conn->callError($topic->getId(), $topic, 'You are not authorized to perform this action.'.PHP_EOL.$e->getMessage(), [
+                        $appTopic->secure($conn, $topic, $request, $payload, $exclude, $eligible, $provider);
+                    } catch (FirewallRejectionException $e) {
+                        $conn->callError($topic->getId(), $topic, sprintf('You are not authorized to perform this action: %s', $e->getMessage()), [
                             'topic' => $topic,
                             'request' => $request,
                             'event' => $calledMethod,

--- a/Server/App/Dispatcher/TopicDispatcher.php
+++ b/Server/App/Dispatcher/TopicDispatcher.php
@@ -5,7 +5,8 @@ namespace Gos\Bundle\WebSocketBundle\Server\App\Dispatcher;
 use Gos\Bundle\WebSocketBundle\Router\WampRequest;
 use Gos\Bundle\WebSocketBundle\Router\WampRouter;
 use Gos\Bundle\WebSocketBundle\Server\App\Registry\TopicRegistry;
-use Gos\Bundle\WebSocketBundle\Topic\FirewalledTopicInterface;
+use Gos\Bundle\WebSocketBundle\Server\Exception\FirewallRejectionException;
+use Gos\Bundle\WebSocketBundle\Topic\SecuredTopicInterface;
 use Gos\Bundle\WebSocketBundle\Topic\PushableTopicInterface;
 use Gos\Bundle\WebSocketBundle\Topic\TopicPeriodicTimer;
 use Gos\Bundle\WebSocketBundle\Topic\TopicPeriodicTimerInterface;
@@ -14,6 +15,7 @@ use Psr\Log\NullLogger;
 use Ratchet\ConnectionInterface;
 use Ratchet\Wamp\Topic;
 use Ratchet\Wamp\TopicManager;
+
 
 /**
  * @author Johann Saunier <johann_27@hotmail.fr>
@@ -131,27 +133,26 @@ class TopicDispatcher implements TopicDispatcherInterface
     public function dispatch($calledMethod, ConnectionInterface $conn = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null)
     {
         $dispatched = false;
-        
+
         if ($topic) {
 
             foreach ((array) $request->getRoute()->getCallback() as $callback) {
                 $appTopic = $this->topicRegistry->getTopic($callback);
 
-                if ( $appTopic instanceof FirewalledTopicInterface )
-                {
-                    $error = $appTopic->checkConnection($conn, $topic, $request, $payload , $exclude , $eligible , $provider );
-                    
-                    if ( !is_null($error) )
-                    {
-                              $conn->callError($topic->getId(), $topic, 'You are not authorized to perform this action.'.PHP_EOL.$error, [
-                                  'topic' => $topic,
-                                  'request' => $request,
-                                  'event' => $calledMethod,
-                              ]);
+                if ($appTopic instanceof SecuredTopicInterface) {
 
-                              $conn->close();
-                              $dispatched = false;
-                              return $dispatched ;
+                    try {
+                        $appTopic->secure($conn, $topic, $request, $payload , $exclude , $eligible , $provider);
+                    } catch ( FirewallRejectionException $e ) {
+                        $conn->callError($topic->getId(), $topic, 'You are not authorized to perform this action.'.PHP_EOL.$e->getMessage(), [
+                            'topic' => $topic,
+                            'request' => $request,
+                            'event' => $calledMethod,
+                        ]);
+
+                        $conn->close();
+                        $dispatched = false;
+                        return $dispatched ;
                     }
                 }
 

--- a/Server/Exception/FirewallRejectionException.php
+++ b/Server/Exception/FirewallRejectionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Gos\Bundle\WebSocketBundle\Server\Exception;
+
+/**
+ * @author Alberto Ghiribaldi <ghiribaldi.alberto@gmail.com>
+ */
+class FirewallRejectionException extends \Exception
+{
+}

--- a/Topic/FirewalledTopicInterface.php
+++ b/Topic/FirewalledTopicInterface.php
@@ -14,7 +14,7 @@ interface FirewalledTopicInterface
      * @param null|string         $payload
      * @param string[]|null       $exclude
      * @param string[]|null       $eligible
-     * @param string|null
+     * @param string|null         $provider
      *
      * @return string|null        $error
      */

--- a/Topic/FirewalledTopicInterface.php
+++ b/Topic/FirewalledTopicInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gos\Bundle\WebSocketBundle\Topic;
+
+use Ratchet\ConnectionInterface;
+use Gos\Bundle\WebSocketBundle\Router\WampRequest;
+use Ratchet\Wamp\Topic;
+
+interface FirewalledTopicInterface
+{
+    /**
+     * @param ConnectionInterface $conn
+     * @param Topic               $topic
+     * @param null|string         $payload
+     * @param string[]|null       $exclude
+     * @param string[]|null       $eligible
+     * @param string|null
+     *
+     * @return string|null        $error
+     */
+    public function checkConnection(ConnectionInterface $conn = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null);
+}

--- a/Topic/SecuredTopicInterface.php
+++ b/Topic/SecuredTopicInterface.php
@@ -4,9 +4,10 @@ namespace Gos\Bundle\WebSocketBundle\Topic;
 
 use Ratchet\ConnectionInterface;
 use Gos\Bundle\WebSocketBundle\Router\WampRequest;
+use Gos\Bundle\WebSocketBundle\Server\Exception\FirewallRejectionException;
 use Ratchet\Wamp\Topic;
 
-interface FirewalledTopicInterface
+interface SecuredTopicInterface
 {
     /**
      * @param ConnectionInterface $conn
@@ -16,7 +17,7 @@ interface FirewalledTopicInterface
      * @param string[]|null       $eligible
      * @param string|null         $provider
      *
-     * @return string|null        $error
+     * @throws \Gos\Bundle\WebSocketBundle\Server\Exception\FirewallRejectionException
      */
-    public function checkConnection(ConnectionInterface $conn = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null);
+    public function secure(ConnectionInterface $conn = null, Topic $topic, WampRequest $request, $payload = null, $exclude = null, $eligible = null, $provider = null);
 }


### PR DESCRIPTION
I added a new interface, `FirewalledTopicInterface`, that allows adding logic inside user's topic service to close unwanted connections.

I extended the current TopicDispatcher to handle this type of topic service. 

Modifications are pretty strightforward, the only issue is that:
- IF a client connects to more than one topic
- AND one of them fails
- the connection is closed, disconnecting from ALL topics

I do not know if this is the correct behaviour, it is a conservative approach though.

