### PR TITLE
Bump pubsub dependency to 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "gos/pubsub-router-bundle": "~0.2.0",
+        "gos/pubsub-router-bundle": "~0.3.0",
         "gos/websocket-client": "~0.1.0",
         "gos/ratchet-stack": "~0.1",
         "gos/pnctl-event-loop-emitter" : "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "gos/pubsub-router-bundle": "~0.3.0",
+        "gos/pubsub-router-bundle": "~0.2",
         "gos/websocket-client": "~0.1.0",
         "gos/ratchet-stack": "~0.1",
         "gos/pnctl-event-loop-emitter" : "~0.1",


### PR DESCRIPTION
Bump the pubsub router bundle dependency to the 0.3 tag.  Since Composer handles 0.x in a "special" way, I can't think of another way to bump this without having a `0.*` type of constraint which isn't optimal when you don't have a 1.0 release yet.