### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Let's do it !
 Installation Instructions
 -------------------------
 
-###Step 1: Install via composer
+### Step 1: Install via composer
 
 `composer require gos/web-socket-bundle`
 
-###Step 2: Add to your App Kernel
+### Step 2: Add to your App Kernel
 
 ```php
 <?php
@@ -90,7 +90,7 @@ public function registerBundles()
     );
 }
 ```
-###Step 3: Configure WebSocket Server
+### Step 3: Configure WebSocket Server
 
 Add the following to your app/config.yml
 

--- a/Resources/docs/ClientSetup.md
+++ b/Resources/docs/ClientSetup.md
@@ -1,6 +1,6 @@
-#Client Setup
+# Client Setup
 
-###Step 1: Include Javascript
+### Step 1: Include Javascript
 To include the relevant javascript libraries necessary for Gos WebSocket, add these to your root layout file just before the closing body tag.
 
 ```twig
@@ -23,7 +23,7 @@ php app/console assetic:dump --env=prod --no-debug
 
 This is to ensure the client js libraries are available.
 
-###Step 2: gos_web_socket_client.js
+### Step 2: gos_web_socket_client.js
 
 Once the javascript is included, you can start using gos_web_socket_client.js to interact with the web socket server. If you want to avoid hardcoding the connection URI here, see the code tip on [sharing the config](code/SharingConfig.md)
 

--- a/Resources/docs/Events.md
+++ b/Resources/docs/Events.md
@@ -1,4 +1,4 @@
-#Events
+# Events
 
 Sometimes you will need to perform a server side action when a user connects or disconnects. Gos WebSocket will fire events for many reasons:
 
@@ -10,7 +10,7 @@ Sometimes you will need to perform a server side action when a user connects or 
 
 By using Symfony2 Event Listeners, you can be notified when any of these events occur.
 
-###Step 1: Create Event Listener Class
+### Step 1: Create Event Listener Class
 
 Create a [Symfony 2 event listener class](http://symfony.com/doc/current/cookbook/service_container/event_listener.html)
 
@@ -88,11 +88,11 @@ class AcmeClientEventListener
 }
 ```
 
-###Step 2: Register it as a service
+### Step 2: Register it as a service
 
 Add this to your bundles "services.yml"
 
-####Available events:
+#### Available events:
 * **gos_web_socket.server_launched**
 * **gos_web_socket.client_connected**
 * **gos_web_socket.client_disconnected**

--- a/Resources/docs/PeriodicSetup.md
+++ b/Resources/docs/PeriodicSetup.md
@@ -1,10 +1,10 @@
-#Periodic Function Services
+# Periodic Function Services
 
 With realtime applications, sometimes you need code to be executed regardless of events, e.g. a matchmaking engine.
 
 With Gos WebSocket these can easily be added and will run within the [React Server](http://reactphp.org/) event loop.
 
-##Step 1: Create the Periodic Service Class
+## Step 1: Create the Periodic Service Class
 
 Every periodic service must implement the PeriodicInterface.
 
@@ -38,7 +38,7 @@ class AcmePeriodic implements PeriodicInterface
 
 ```
 
-##Step 2: Register your service with Symfony
+## Step 2: Register your service with Symfony
 
 If you are using YML, edit "YourBundle/Resources/config/services/services.yml"
 For other formats, please check the [Symfony2 Documents](http://symfony.com/doc/master/book/service_container.html)

--- a/Resources/docs/RPCSetup.md
+++ b/Resources/docs/RPCSetup.md
@@ -1,4 +1,4 @@
-#Remote Procedure Call Setup
+# Remote Procedure Call Setup
 
 Every remote procedure call (RPC) in Gos WebSocket has its own "network namespace" in order to dispatch requests to the correct command.
 
@@ -6,12 +6,12 @@ In Symfony RPCs are setup as services. This allows you full control of what to d
 
 If you are new to services, please see [Symfony2: Service Container](http://symfony.com/doc/master/book/service_container.html)
 
-##Overview
+## Overview
 * Create the service class
 * Register you service with Symfony
 * Register your service with PubSubRouter
 
-##Step 1: Create the Service Class
+## Step 1: Create the Service Class
 
 ```php
 <?php
@@ -57,7 +57,7 @@ To return a result from the procedure, simply return anything other than false o
 
 If you return false or null, it will return an error to the client, informing them the procedure call did not work correctly.
 
-##Step 2: Register your service with Symfony
+## Step 2: Register your service with Symfony
 
 If you are using YML, edit "YourBundle/Resources/config/services.yml", add:
 
@@ -106,7 +106,7 @@ e.g.
 
 The idea of having these network namespaces is to group relevant code into separate files.
 
-##Step 3: Register your service with PubSubRouter
+## Step 3: Register your service with PubSubRouter
 
 Now you have create your RPC service and implements your RPC call in the client, you must now link the path with your service.  `sample/add_func` will refer to AcmeService
 

--- a/Resources/docs/SessionSetup.md
+++ b/Resources/docs/SessionSetup.md
@@ -1,4 +1,4 @@
-#Session sharing and user authentication
+# Session sharing and user authentication
 
 Thanks to Ratchet its easy to get the shared info from the same website session. As per the
 [Ratchet documentation](http://socketo.me/docs/sessions), you must use a session handler other than the native one,
@@ -58,11 +58,11 @@ User is directly authenticated against his firewall, anonymous users are allow.
 **Anonymous user is represented by string, example : anon-54e3352d535d2**
 **Authenticated user is represented by UserInterface object**
 
-##Client storage
+## Client storage
 
 Each user connected to socket is persisted in our persistence layer. By default they are stored in php via SplStorage.
 
-###Customize client storage
+### Customize client storage
 
 ```yaml
 gos_web_socket:
@@ -222,7 +222,7 @@ services:
 
 **NOTE :** Predis driver class is included in GosWebSocketBundle, just register the service like below to use it.
 
-#Retrieve authenticated user
+# Retrieve authenticated user
 
 Whenever `ConnectionInterface` instance is available your are able to retrieve the associated authenticated user (if he is authenticated against symfony firewall).
 

--- a/Resources/docs/ShipInProduction.md
+++ b/Resources/docs/ShipInProduction.md
@@ -1,4 +1,4 @@
-#Ship in production
+# Ship in production
 
 How run your websocket server in production ?
 ---------------------------------------------

--- a/Resources/docs/Ssl.md
+++ b/Resources/docs/Ssl.md
@@ -1,8 +1,8 @@
-#SSL Configuration
+# SSL Configuration
 
 For wss:// connections we recommend using stunnel. It is used to open a secured port and then forward it to a not secured port on the same other different machine. You can also use Nginx or HaProxy
 
-##Using stunnel
+## Using stunnel
 
 Install [Stunnel](https://www.stunnel.org/index.html) : 
 
@@ -30,12 +30,12 @@ pid = /stunnel.pid
 
 # Only use this options if for making it more secure after you get it to work.
 # User id
-#setuid = nobody
+# setuid = nobody
 # Group id
-#setgid = nobody
+# setgid = nobody
 
 # IMPORTANT: If the websocketserver is on the same server as the webserver use this:
-#local = my.domainname.com # Insert here your domain that is secured with https.
+# local = my.domainname.com # Insert here your domain that is secured with https.
 
 [websockets]
 accept = 8443

--- a/Resources/docs/TopicSetup.md
+++ b/Resources/docs/TopicSetup.md
@@ -1,4 +1,4 @@
-#Topic Handler Setup
+# Topic Handler Setup
 
 Although the standard Gos WebSocket PubSub can be useful as a simple channel for allowing messages to be pushed to users, anymore advanced functionality will require custom Topic Handlers.
 
@@ -9,14 +9,14 @@ A topic is the server side representation of a pubsub channel.
 
 You just have to register a topic who catch all channel prefixed by `chat` to handle pubsub. A topic can only support one prefix.
 
-##Overview
+## Overview
 
 * Create the topic handler service
 * Register your service with symfony
 * Connect the client with your topic
 * Link the topic with channel with pubsub router
 
-##Step 1: Create the Topic Handler Service
+## Step 1: Create the Topic Handler Service
 
 ```php
 <?php
@@ -244,7 +244,7 @@ public function onSubscribe(ConnectionInterface $connection, Topic $topic, WampR
 
 :collision: **Periodic timer is bind on the current connection ! So if you broadcast from periodic timer your clients will recieve this message x * the number of subscribers**
 
-##Step 2: Register your service with Symfony
+## Step 2: Register your service with Symfony
 
 If you are using **YML**, edit `YourBundle/Resources/config/services.yml`
 
@@ -278,7 +278,7 @@ gos_web_socket:
 
 Look at [here](SessionSetup.md)
 
-##Step 3: Connect client to your topics
+## Step 3: Connect client to your topics
 The following javascript will show connecting to this topic, notice how "acme/channel" will match the name "acme" we gave the service.
 
 ```javascript
@@ -296,7 +296,7 @@ The following javascript will show connecting to this topic, notice how "acme/ch
     session.publish("acme/channel", {msg: "I won't see this"});
 ```
 
-##Step 4 : Link channel & topic with pubsub router
+## Step 4 : Link channel & topic with pubsub router
 
 * Channel can be static e.g : `acme/user`
 * Channel can be dynamic e.g : `acme/user/*`
@@ -328,7 +328,7 @@ acme_topic:
         callback: 'acme.topic' #related to the getName() of your topic
 ```
 
-###Advanced example
+### Advanced example
 
 ```yaml
 acme_topic_chat:

--- a/Resources/docs/code/SharingConfig.md
+++ b/Resources/docs/code/SharingConfig.md
@@ -1,4 +1,4 @@
-#Share config between server and client
+# Share config between server and client
 
 Its useful to keep the server configuration isolated from the application. Here is a trivial way to share the Gos WebSocket Config between the server and the client.
 
@@ -11,7 +11,7 @@ gos_web_socket:
 
 ## How Access to the shared config
 
-###Twig
+### Twig
 ```html
 <script type="text/javascript">
     var _WS_URI = "ws://{{ gos_web_socket_server_host }}:{{ gos_web_socket_server_port }}";
@@ -26,7 +26,7 @@ var myWs = WS.connect(_WS_URI);
 
 Alternatively, if you don't like polluting your global scope, you can render it directly into your javascript file by processing it via a controller.
 
-###Symfony2 DIC
+### Symfony2 DIC
 
 In service YAML :
 ```yaml


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
