### PR TITLE
Change verbosity level onPublish

### DIFF
--- a/Server/App/WampApplication.php
+++ b/Server/App/WampApplication.php
@@ -89,7 +89,7 @@ class WampApplication implements WampServerInterface
         $user = $this->clientStorage->getClient($conn->WAMP->clientStorageId);
         $username = $user instanceof UserInterface ? $user->getUsername() : $user;
 
-        $this->logger->info(sprintf(
+        $this->logger->debug(sprintf(
             '%s publish to %s',
             $username,
             $topic->getId()


### PR DESCRIPTION
Use debug verbosity level debug instead of info when publishing. It pollutes your log when sending huge amount of messages per minute.