### PR TITLE
[#280] Do not instantiate PDOSessionHandler at build time

### DIFF
--- a/DependencyInjection/CompilerPass/PingableDriverCompilerPass.php
+++ b/DependencyInjection/CompilerPass/PingableDriverCompilerPass.php
@@ -3,10 +3,8 @@
 namespace Gos\Bundle\WebSocketBundle\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
 class PingableDriverCompilerPass implements CompilerPassInterface
 {
@@ -23,9 +21,9 @@ class PingableDriverCompilerPass implements CompilerPassInterface
             return;
         }
 
-        $sessionHandler = $container->get((string) $container->getAlias('gos_web_socket.session_handler'));
+        $sessionHandlerDefinition = $container->getDefinition((string) $container->getAlias('gos_web_socket.session_handler'));
 
-        if (false === $sessionHandler instanceof PdoSessionHandler) {
+        if (!\in_array(\SessionHandlerInterface::class, \class_implements($sessionHandlerDefinition->getClass()), true)) {
             return;
         }
 

--- a/Resources/docs/SessionSetup.md
+++ b/Resources/docs/SessionSetup.md
@@ -34,6 +34,16 @@ arguments:
     - '%database_password%'
 ```  
 
+If you're using Doctrine & want to re-use the same connection:
+
+```yml
+services:
+    session.handler.pdo:
+        class:     Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
+        arguments: 
+            - !service { class: PDO, factory: 'database_connection:getWrappedConnection' }
+            - {lock_mode: 0}
+````
 
 [Create table in your DB](http://symfony.com/doc/current/cookbook/configuration/pdo_session_storage.html#mysql)
 


### PR DESCRIPTION
Database session can't be defined like recommended in http://symfony.com/doc/current/doctrine/pdo_session_storage.html

    Constructing service "doctrine.dbal.default_connection" from a parent definition is not supported at build time.
