### PR TITLE
Refactor/ratchet 0.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer install --prefer-source --no-interaction
+
+script:
+- phpunit -c phpunit.xml --coverage-text

--- a/Event/ClientRejectedEvent.php
+++ b/Event/ClientRejectedEvent.php
@@ -2,7 +2,8 @@
 
 namespace Gos\Bundle\WebSocketBundle\Event;
 
-use Guzzle\Http\Message\RequestInterface;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -16,7 +17,7 @@ class ClientRejectedEvent extends Event
     protected $origin;
 
     /**
-     * @var RequestInterface
+     * @var Request
      */
     protected $request;
 

--- a/Event/StartServerListener.php
+++ b/Event/StartServerListener.php
@@ -57,7 +57,7 @@ class StartServerListener
         }
 
         $server->emit('end');
-        $server->shutdown();
+        $server->close();
 
         foreach ($this->periodicRegistry->getPeriodics() as $periodic) {
             if ($periodic instanceof TimerInterface && $loop->isTimerActive($periodic)) {

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -229,7 +229,10 @@ services:
             - { name: gos_web_socket.push_handler, alias: amqp }
 
     gos_web_socket.wamp.topic_manager:
-        class: Ratchet\Wamp\TopicManager
+        class: Gos\Bundle\WebSocketBundle\Topic\TopicManager
+        arguments:
+            - '@gos_web_socket_server.wamp_application'
+
 
     gos_web_socket.kernel_event.terminate:
         class: Gos\Bundle\WebSocketBundle\Event\KernelTerminateListener

--- a/Server/App/Dispatcher/TopicDispatcher.php
+++ b/Server/App/Dispatcher/TopicDispatcher.php
@@ -8,13 +8,13 @@ use Gos\Bundle\WebSocketBundle\Server\App\Registry\TopicRegistry;
 use Gos\Bundle\WebSocketBundle\Server\Exception\FirewallRejectionException;
 use Gos\Bundle\WebSocketBundle\Topic\SecuredTopicInterface;
 use Gos\Bundle\WebSocketBundle\Topic\PushableTopicInterface;
+use Gos\Bundle\WebSocketBundle\Topic\TopicManager;
 use Gos\Bundle\WebSocketBundle\Topic\TopicPeriodicTimer;
 use Gos\Bundle\WebSocketBundle\Topic\TopicPeriodicTimerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Ratchet\ConnectionInterface;
 use Ratchet\Wamp\Topic;
-use Ratchet\Wamp\TopicManager;
 
 
 /**
@@ -51,7 +51,9 @@ class TopicDispatcher implements TopicDispatcherInterface
 
     const PUSH = 'onPush';
 
-    /**
+    /**use Ratchet\MessageComponentInterface;
+    use Ratchet\WebSocket\WsServerInterface;
+    use Ratchet\ConnectionInterface;
      * @param TopicRegistry        $topicRegistry
      * @param WampRouter           $router
      * @param TopicPeriodicTimer   $topicPeriodicTimer

--- a/Server/App/Stack/OriginCheck.php
+++ b/Server/App/Stack/OriginCheck.php
@@ -4,7 +4,9 @@ namespace Gos\Bundle\WebSocketBundle\Server\App\Stack;
 
 use Gos\Bundle\WebSocketBundle\Event\ClientRejectedEvent;
 use Gos\Bundle\WebSocketBundle\Event\Events;
-use Guzzle\Http\Message\RequestInterface;
+use GuzzleHttp\Psr7 as gPsr;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
 use Ratchet\ConnectionInterface;
 use Ratchet\Http\OriginCheck as BaseOriginCheck;
 use Ratchet\MessageComponentInterface;
@@ -19,19 +21,26 @@ class OriginCheck extends BaseOriginCheck
      * @var EventDispatcherInterface
      */
     protected $eventDispatcher;
+    /**
+     * @var bool
+     */
+    private $check;
 
     /**
      * @param MessageComponentInterface $component
+     * @param bool                      $check
      * @param string[]                  $allowed
      * @param EventDispatcherInterface  $eventDispatcher
      */
     public function __construct(
         MessageComponentInterface $component,
+        $check = true,
         array $allowed = array(),
         EventDispatcherInterface $eventDispatcher
     ) {
         $this->eventDispatcher = $eventDispatcher;
         parent::__construct($component, $allowed);
+        $this->check = $check;
     }
 
     /**
@@ -39,7 +48,12 @@ class OriginCheck extends BaseOriginCheck
      */
     public function onOpen(ConnectionInterface $conn, RequestInterface $request = null)
     {
-        $header = (string) $request->getHeader('Origin');
+        if (!$this->check) {
+            return $this->_component->onOpen($conn, $request);
+        }
+
+        $header = (string) $request->getHeaderLine('Origin');
+
         $origin = parse_url($header, PHP_URL_HOST) ?: $header;
 
         if (!in_array($origin, $this->allowedOrigins)) {
@@ -52,5 +66,19 @@ class OriginCheck extends BaseOriginCheck
         }
 
         return $this->_component->onOpen($conn, $request);
+    }
+
+    /**
+     * Close a connection with an HTTP response
+     * @param \Ratchet\ConnectionInterface $conn
+     * @param int                          $code HTTP status code
+     */
+    protected function close(ConnectionInterface $conn, $code = 400, array $additional_headers = []) {
+        $response = new Response($code, array_merge([
+            'X-Powered-By' => \Ratchet\VERSION
+        ], $additional_headers));
+
+        $conn->send(gPsr\str($response));
+        $conn->close();
     }
 }

--- a/Server/App/Stack/OriginCheck.php
+++ b/Server/App/Stack/OriginCheck.php
@@ -35,9 +35,10 @@ class OriginCheck extends BaseOriginCheck
     public function __construct(
         MessageComponentInterface $component,
         $check = true,
-        array $allowed = array(),
+        array $allowed = [],
         EventDispatcherInterface $eventDispatcher
-    ) {
+    )
+    {
         $this->eventDispatcher = $eventDispatcher;
         parent::__construct($component, $allowed);
         $this->check = $check;
@@ -52,7 +53,7 @@ class OriginCheck extends BaseOriginCheck
             return $this->_component->onOpen($conn, $request);
         }
 
-        $header = (string) $request->getHeaderLine('Origin');
+        $header = (string)$request->getHeaderLine('Origin');
 
         $origin = parse_url($header, PHP_URL_HOST) ?: $header;
 
@@ -70,12 +71,14 @@ class OriginCheck extends BaseOriginCheck
 
     /**
      * Close a connection with an HTTP response
+     *
      * @param \Ratchet\ConnectionInterface $conn
      * @param int                          $code HTTP status code
      */
-    protected function close(ConnectionInterface $conn, $code = 400, array $additional_headers = []) {
+    protected function close(ConnectionInterface $conn, $code = 400, array $additional_headers = [])
+    {
         $response = new Response($code, array_merge([
-            'X-Powered-By' => \Ratchet\VERSION
+            'X-Powered-By' => \Ratchet\VERSION,
         ], $additional_headers));
 
         $conn->send(gPsr\str($response));

--- a/Server/App/WampApplication.php
+++ b/Server/App/WampApplication.php
@@ -133,6 +133,7 @@ class WampApplication implements WampServerInterface
      */
     public function onSubscribe(ConnectionInterface $conn, $topic)
     {
+
         $user = $this->clientStorage->getClient($conn->WAMP->clientStorageId);
         $username = $user instanceof UserInterface ? $user->getUsername() : $user;
 

--- a/Server/Type/WebSocketServer.php
+++ b/Server/Type/WebSocketServer.php
@@ -149,16 +149,19 @@ class WebSocketServer implements ServerInterface
 
         $allowedOrigins = array_merge(array('localhost', '127.0.0.1'), $this->originRegistry->getOrigins());
 
+        $wsServer = new WsServer(
+            new WampConnectionPeriodicTimer(
+                new WampServer($this->wampApplication, $this->topicManager),
+                $this->loop
+            )
+        );
+        $wsServer->setStrictSubProtocolCheck(false);
+
         $app = new IoServer(
             new HttpServer(
                 new OriginCheck(
                     new SessionProvider(
-                        new WsServer(
-                            new WampConnectionPeriodicTimer(
-                                new WampServer($this->wampApplication, $this->topicManager),
-                                $this->loop
-                            )
-                        ),
+                        $wsServer,
                         $this->sessionHandler
                     ),
                     $this->originCheck,

--- a/Server/WampServer.php
+++ b/Server/WampServer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Gos\Bundle\WebSocketBundle\Server;
+
+use Gos\Bundle\WebSocketBundle\Topic\TopicManager;
+use Ratchet\MessageComponentInterface;
+use Ratchet\Wamp\ServerProtocol;
+use Ratchet\Wamp\WampServerInterface;
+use Ratchet\WebSocket\WsServerInterface;
+use Ratchet\ConnectionInterface;
+
+/**
+ * Class WampServer
+ *
+ * @author Edu Salguero <edusalguero@gmail.com>
+ */
+class WampServer implements MessageComponentInterface, WsServerInterface {
+    /**
+     * @var ServerProtocol
+     */
+    protected $wampProtocol;
+
+    /**
+     * This class just makes it 1 step easier to use Topic objects in WAMP
+     * If you're looking at the source code, look in the __construct of this
+     *  class and use that to make your application instead of using this
+     */
+    public function __construct(WampServerInterface $app, TopicManager $topicManager) {
+        $this->wampProtocol = new ServerProtocol($topicManager);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onOpen(ConnectionInterface $conn) {
+        $this->wampProtocol->onOpen($conn);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onMessage(ConnectionInterface $conn, $msg) {
+        try {
+            $this->wampProtocol->onMessage($conn, $msg);
+        } catch (Exception $we) {
+            $conn->close(1007);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onClose(ConnectionInterface $conn) {
+        $this->wampProtocol->onClose($conn);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onError(ConnectionInterface $conn, \Exception $e) {
+        $this->wampProtocol->onError($conn, $e);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubProtocols() {
+        return $this->wampProtocol->getSubProtocols();
+    }
+}
+

--- a/Server/WampServer.php
+++ b/Server/WampServer.php
@@ -3,18 +3,19 @@
 namespace Gos\Bundle\WebSocketBundle\Server;
 
 use Gos\Bundle\WebSocketBundle\Topic\TopicManager;
+use Ratchet\ConnectionInterface;
 use Ratchet\MessageComponentInterface;
 use Ratchet\Wamp\ServerProtocol;
 use Ratchet\Wamp\WampServerInterface;
 use Ratchet\WebSocket\WsServerInterface;
-use Ratchet\ConnectionInterface;
 
 /**
  * Class WampServer
  *
  * @author Edu Salguero <edusalguero@gmail.com>
  */
-class WampServer implements MessageComponentInterface, WsServerInterface {
+class WampServer implements MessageComponentInterface, WsServerInterface
+{
     /**
      * @var ServerProtocol
      */
@@ -25,21 +26,24 @@ class WampServer implements MessageComponentInterface, WsServerInterface {
      * If you're looking at the source code, look in the __construct of this
      *  class and use that to make your application instead of using this
      */
-    public function __construct(WampServerInterface $app, TopicManager $topicManager) {
+    public function __construct(WampServerInterface $app, TopicManager $topicManager)
+    {
         $this->wampProtocol = new ServerProtocol($topicManager);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onOpen(ConnectionInterface $conn) {
+    public function onOpen(ConnectionInterface $conn)
+    {
         $this->wampProtocol->onOpen($conn);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onMessage(ConnectionInterface $conn, $msg) {
+    public function onMessage(ConnectionInterface $conn, $msg)
+    {
         try {
             $this->wampProtocol->onMessage($conn, $msg);
         } catch (Exception $we) {
@@ -50,21 +54,24 @@ class WampServer implements MessageComponentInterface, WsServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onClose(ConnectionInterface $conn) {
+    public function onClose(ConnectionInterface $conn)
+    {
         $this->wampProtocol->onClose($conn);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, \Exception $e)
+    {
         $this->wampProtocol->onError($conn, $e);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getSubProtocols() {
+    public function getSubProtocols()
+    {
         return $this->wampProtocol->getSubProtocols();
     }
 }

--- a/Server/WampServer.php
+++ b/Server/WampServer.php
@@ -46,7 +46,7 @@ class WampServer implements MessageComponentInterface, WsServerInterface
     {
         try {
             $this->wampProtocol->onMessage($conn, $msg);
-        } catch (Exception $we) {
+        } catch (\Exception $we) {
             $conn->close(1007);
         }
     }
@@ -75,4 +75,3 @@ class WampServer implements MessageComponentInterface, WsServerInterface
         return $this->wampProtocol->getSubProtocols();
     }
 }
-

--- a/Topic/TopicManager.php
+++ b/Topic/TopicManager.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Gos\Bundle\WebSocketBundle\Topic;
+
+
+use Ratchet\ConnectionInterface;
+use Ratchet\Wamp\Topic;
+use Ratchet\Wamp\WampServerInterface;
+use Ratchet\WebSocket\WsServerInterface;
+
+/**
+ * Class TopicManager
+ *
+ * @author Edu Salguero <edusalguero@gmail.com>
+ */
+class TopicManager implements WsServerInterface, WampServerInterface {
+    /**
+     * @var WampServerInterface
+     */
+    protected $app;
+
+    /**
+     * @var array
+     */
+    protected $topicLookup = array();
+
+    public function __construct(WampServerInterface $app) {
+        $this->app = $app;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onOpen(ConnectionInterface $conn) {
+        $conn->WAMP->subscriptions = new \SplObjectStorage;
+        $this->app->onOpen($conn);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onCall(ConnectionInterface $conn, $id, $topic, array $params) {
+        $this->app->onCall($conn, $id, $this->getTopic($topic), $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onSubscribe(ConnectionInterface $conn, $topic) {
+        $topicObj = $this->getTopic($topic);
+
+        if ($conn->WAMP->subscriptions->contains($topicObj)) {
+            return;
+        }
+
+        $this->topicLookup[$topic]->add($conn);
+        $conn->WAMP->subscriptions->attach($topicObj);
+        $this->app->onSubscribe($conn, $topicObj);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onUnsubscribe(ConnectionInterface $conn, $topic) {
+        $topicObj = $this->getTopic($topic);
+
+        if (!$conn->WAMP->subscriptions->contains($topicObj)) {
+            return;
+        }
+
+        $this->cleanTopic($topicObj, $conn);
+
+        $this->app->onUnsubscribe($conn, $topicObj);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onPublish(ConnectionInterface $conn, $topic, $event, array $exclude, array $eligible) {
+        $this->app->onPublish($conn, $this->getTopic($topic), $event, $exclude, $eligible);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onClose(ConnectionInterface $conn) {
+        $this->app->onClose($conn);
+
+        foreach ($this->topicLookup as $topic) {
+            $this->cleanTopic($topic, $conn);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onError(ConnectionInterface $conn, \Exception $e) {
+        $this->app->onError($conn, $e);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubProtocols() {
+        if ($this->app instanceof WsServerInterface) {
+            return $this->app->getSubProtocols();
+        }
+
+        return array();
+    }
+
+    /**
+     * @param string
+     * @return Topic
+     */
+    public function getTopic($topic) {
+        if (!array_key_exists($topic, $this->topicLookup)) {
+            $this->topicLookup[$topic] = new Topic($topic);
+        }
+
+        return $this->topicLookup[$topic];
+    }
+
+    protected function cleanTopic(Topic $topic, ConnectionInterface $conn) {
+        if ($conn->WAMP->subscriptions->contains($topic)) {
+            $conn->WAMP->subscriptions->detach($topic);
+        }
+
+        $this->topicLookup[$topic->getId()]->remove($conn);
+    }
+}

--- a/Topic/TopicManager.php
+++ b/Topic/TopicManager.php
@@ -2,7 +2,6 @@
 
 namespace Gos\Bundle\WebSocketBundle\Topic;
 
-
 use Ratchet\ConnectionInterface;
 use Ratchet\Wamp\Topic;
 use Ratchet\Wamp\WampServerInterface;

--- a/Topic/TopicManager.php
+++ b/Topic/TopicManager.php
@@ -13,7 +13,8 @@ use Ratchet\WebSocket\WsServerInterface;
  *
  * @author Edu Salguero <edusalguero@gmail.com>
  */
-class TopicManager implements WsServerInterface, WampServerInterface {
+class TopicManager implements WsServerInterface, WampServerInterface
+{
     /**
      * @var WampServerInterface
      */
@@ -22,16 +23,18 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     /**
      * @var array
      */
-    protected $topicLookup = array();
+    protected $topicLookup = [];
 
-    public function __construct(WampServerInterface $app) {
+    public function __construct(WampServerInterface $app)
+    {
         $this->app = $app;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onOpen(ConnectionInterface $conn) {
+    public function onOpen(ConnectionInterface $conn)
+    {
         $conn->WAMP->subscriptions = new \SplObjectStorage;
         $this->app->onOpen($conn);
     }
@@ -39,14 +42,16 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onCall(ConnectionInterface $conn, $id, $topic, array $params) {
+    public function onCall(ConnectionInterface $conn, $id, $topic, array $params)
+    {
         $this->app->onCall($conn, $id, $this->getTopic($topic), $params);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onSubscribe(ConnectionInterface $conn, $topic) {
+    public function onSubscribe(ConnectionInterface $conn, $topic)
+    {
         $topicObj = $this->getTopic($topic);
 
         if ($conn->WAMP->subscriptions->contains($topicObj)) {
@@ -61,7 +66,8 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onUnsubscribe(ConnectionInterface $conn, $topic) {
+    public function onUnsubscribe(ConnectionInterface $conn, $topic)
+    {
         $topicObj = $this->getTopic($topic);
 
         if (!$conn->WAMP->subscriptions->contains($topicObj)) {
@@ -76,14 +82,16 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onPublish(ConnectionInterface $conn, $topic, $event, array $exclude, array $eligible) {
+    public function onPublish(ConnectionInterface $conn, $topic, $event, array $exclude, array $eligible)
+    {
         $this->app->onPublish($conn, $this->getTopic($topic), $event, $exclude, $eligible);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function onClose(ConnectionInterface $conn) {
+    public function onClose(ConnectionInterface $conn)
+    {
         $this->app->onClose($conn);
 
         foreach ($this->topicLookup as $topic) {
@@ -94,26 +102,30 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, \Exception $e)
+    {
         $this->app->onError($conn, $e);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getSubProtocols() {
+    public function getSubProtocols()
+    {
         if ($this->app instanceof WsServerInterface) {
             return $this->app->getSubProtocols();
         }
 
-        return array();
+        return [];
     }
 
     /**
      * @param string
+     *
      * @return Topic
      */
-    public function getTopic($topic) {
+    public function getTopic($topic)
+    {
         if (!array_key_exists($topic, $this->topicLookup)) {
             $this->topicLookup[$topic] = new Topic($topic);
         }
@@ -121,7 +133,8 @@ class TopicManager implements WsServerInterface, WampServerInterface {
         return $this->topicLookup[$topic];
     }
 
-    protected function cleanTopic(Topic $topic, ConnectionInterface $conn) {
+    protected function cleanTopic(Topic $topic, ConnectionInterface $conn)
+    {
         if ($conn->WAMP->subscriptions->contains($topic)) {
             $conn->WAMP->subscriptions->detach($topic);
         }

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,12 @@
         "symfony/framework-bundle": "^2.3|^3.0|^4.0",
         "gos/pubsub-router-bundle": "^0.3",
         "gos/websocket-client": "^0.1",
-        "gos/ratchet-stack": "^0.1",
         "gos/pnctl-event-loop-emitter" : "^0.1",
-        "gos/ratchet": "^0.3"
+        "ocramius/proxy-manager": "^2.1",
+        "cboden/ratchet": "^0.4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"
-    },
-    "replace" : {
-        "cboden/ratchet": "^0.3"
     },
     "autoload": {
         "psr-4": { "Gos\\Bundle\\WebSocketBundle\\": "" }
@@ -38,8 +35,7 @@
       "ext-libev": "*",
       "ext-zmq": "*",
       "ext-amqp": "*",
-      "symfony/proxy-manager-bridge": "~2.3",
-      "ocramius/proxy-manager": "~1.0"
+      "symfony/proxy-manager-bridge": "~2.3"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "gos/pubsub-router-bundle": "^0.3",
         "gos/websocket-client": "^0.1",
         "gos/pnctl-event-loop-emitter" : "^0.1",
-        "ocramius/proxy-manager": "^2.1",
+        "ocramius/proxy-manager": "^1.0|^2.1",
         "cboden/ratchet": "^0.4.1"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="WebSocketBundle for the Symfony Framework">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
After a small refactor I have managed to eliminate the `gos/ratchet` and `gos/ratchet-stack` (thanks to the PSR7 ) dependencies and now I'm using the latest  **Ratchet** and **ReactPHP** versions.

I am using the new branch in dev and prod environment for 3 days and it works fine. The applications pass all test (acceptance and load) successfully and there are not reported issues.

I think that the code is ready to be merged and to be released a "2.0" WebSocketBundle version.

Here information about installed packages:
```
cboden/ratchet 		=> v0.4.1                    
react/cache 		=> v0.4.2                    
react/dns 		=> v0.4.12                   
react/event-loop	=> v0.4.3                    
react/promise		=> v2.5.1                    
react/promise-timer	=> v1.2.1                    
react/socket 		=> v0.8.9                    
react/stream 		=> v0.7.6                    
react/zmq 		=> v0.3.0                    

```
Do not hesitate to ask for more information or about the PR.

Thank you for your work.