### PR TITLE
Deprecate duplicate classes

### DIFF
--- a/Client/DoctrineCacheDriverDecorator.php
+++ b/Client/DoctrineCacheDriverDecorator.php
@@ -2,67 +2,15 @@
 
 namespace Gos\Bundle\WebSocketBundle\Client;
 
-use Doctrine\Common\Cache\CacheProvider;
+use Gos\Bundle\WebSocketBundle\Client\Driver\DoctrineCacheDriverDecorator as BaseDoctrineCacheDriverDecorator;
+
+@trigger_error('The DoctrineCacheDriverDecorator class is deprecated will be removed in 2.0. Use the parent DoctrineCacheDriverDecorator instead.', E_USER_DEPRECATED);
 
 /**
  * @author Johann Saunier <johann_27@hotmail.fr>
+ *
+ * @deprecated to be removed in 2.0. Use the parent DoctrineCacheDriverDecorator instead.
  */
-class DoctrineCacheDriverDecorator implements DriverInterface
+class DoctrineCacheDriverDecorator extends BaseDoctrineCacheDriverDecorator implements DriverInterface
 {
-    /**
-     * @var CacheProvider
-     */
-    protected $cacheProvider;
-
-    /**
-     * @param CacheProvider $cacheProvider
-     */
-    public function __construct(CacheProvider $cacheProvider)
-    {
-        $this->cacheProvider = $cacheProvider;
-    }
-
-    /**
-     * @param string $id
-     *
-     * @return mixed
-     */
-    public function fetch($id)
-    {
-        return $this->cacheProvider->fetch($id);
-    }
-
-    /**
-     * @param $id
-     *
-     * @return bool
-     */
-    public function contains($id)
-    {
-        return $this->cacheProvider->contains($id);
-    }
-
-    /**
-     * @param string $id
-     * @param mixed  $data
-     * @param int    $lifeTime
-     *
-     * @return mixed
-     */
-    public function save($id, $data, $lifeTime = 0)
-    {
-        return $this->cacheProvider->save($id, $data, $lifeTime);
-    }
-
-    /**
-     * Deletes a cache entry.
-     *
-     * @param string $id The cache id.
-     *
-     * @return bool TRUE if the cache entry was successfully deleted, FALSE otherwise.
-     */
-    public function delete($id)
-    {
-        return $this->cacheProvider->delete($id);
-    }
 }

--- a/Client/DriverInterface.php
+++ b/Client/DriverInterface.php
@@ -2,37 +2,13 @@
 
 namespace Gos\Bundle\WebSocketBundle\Client;
 
-interface DriverInterface
+use Gos\Bundle\WebSocketBundle\Client\Driver\DriverInterface as BaseDriverInterface;
+
+@trigger_error('The DriverInterface interface is deprecated will be removed in 2.0. Use the parent DriverInterface instead.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated to be removed in 2.0. Use the parent DriverInterface instead.
+ */
+interface DriverInterface extends BaseDriverInterface
 {
-    /**
-     * @param string $id
-     *
-     * @return mixed
-     */
-    public function fetch($id);
-
-    /**
-     * @param $id
-     *
-     * @return bool
-     */
-    public function contains($id);
-
-    /**
-     * @param string $id
-     * @param mixed  $data
-     * @param int    $lifeTime
-     *
-     * @return mixed
-     */
-    public function save($id, $data, $lifeTime = 0);
-
-    /**
-     * Deletes a cache entry.
-     *
-     * @param string $id The cache id.
-     *
-     * @return bool TRUE if the cache entry was successfully deleted, FALSE otherwise.
-     */
-    public function delete($id);
 }


### PR DESCRIPTION
There are duplicate classes for the Doctrine cache decorator and the driver interface.  Deprecate them and point to the actual class/interface used by the bundle.