### PR TITLE
Update react/event-loop dependency to 1.0

### DIFF
--- a/Event/StartServerListener.php
+++ b/Event/StartServerListener.php
@@ -4,7 +4,6 @@ namespace Gos\Bundle\WebSocketBundle\Event;
 
 use Gos\Bundle\WebSocketBundle\Pusher\ServerPushHandlerRegistry;
 use Gos\Bundle\WebSocketBundle\Server\App\Registry\PeriodicRegistry;
-use Gos\Component\PnctlEventLoopEmitter\PnctlEmitter;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use React\EventLoop\LoopInterface;
@@ -75,21 +74,11 @@ class StartServerListener
      */
     public function bindPnctlEvent(ServerEvent $event)
     {
-        if (!extension_loaded('pcntl')) {
-            return;
-        }
-
         $loop = $event->getEventLoop();
         $server = $event->getServer();
 
-        $pnctlEmitter = new PnctlEmitter($loop);
-
-        $pnctlEmitter->on(SIGTERM, function () use ($server, $loop) {
+        $loop->addSignal(SIGTERM, function () use ($server, $loop) {
             $this->closure($server, $loop);
-        });
-
-        $pnctlEmitter->on(SIGINT, function () use ($pnctlEmitter) {
-            $pnctlEmitter->emit(SIGTERM);
         });
     }
 }

--- a/Event/StartServerListener.php
+++ b/Event/StartServerListener.php
@@ -77,7 +77,7 @@ class StartServerListener
         $loop = $event->getEventLoop();
         $server = $event->getServer();
 
-        $loop->addSignal(SIGTERM, function () use ($server, $loop) {
+        $loop->addSignal(SIGINT, function () use ($server, $loop) {
             $this->closure($server, $loop);
         });
     }

--- a/Event/StartServerListener.php
+++ b/Event/StartServerListener.php
@@ -8,7 +8,7 @@ use Gos\Component\PnctlEventLoopEmitter\PnctlEmitter;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Timer\TimerInterface;
+use React\EventLoop\TimerInterface;
 use React\Socket\Server;
 
 class StartServerListener
@@ -60,7 +60,7 @@ class StartServerListener
         $server->close();
 
         foreach ($this->periodicRegistry->getPeriodics() as $periodic) {
-            if ($periodic instanceof TimerInterface && $loop->isTimerActive($periodic)) {
+            if ($periodic instanceof TimerInterface) {
                 $loop->cancelTimer($periodic);
             }
         }

--- a/Server/App/Stack/WampConnectionPeriodicTimer.php
+++ b/Server/App/Stack/WampConnectionPeriodicTimer.php
@@ -7,7 +7,7 @@ use Ratchet\ConnectionInterface;
 use Ratchet\MessageComponentInterface;
 use Ratchet\WebSocket\WsServerInterface;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Timer\TimerInterface;
+use React\EventLoop\TimerInterface;
 
 /**
  * Wrap WampServer nicely.

--- a/Topic/ConnectionPeriodicTimer.php
+++ b/Topic/ConnectionPeriodicTimer.php
@@ -4,11 +4,12 @@ namespace Gos\Bundle\WebSocketBundle\Topic;
 
 use Ratchet\ConnectionInterface;
 use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
 
 class ConnectionPeriodicTimer implements \IteratorAggregate, \Countable
 {
     /**
-     * @var array
+     * @var TimerInterface[]
      */
     protected $registry;
 
@@ -36,7 +37,7 @@ class ConnectionPeriodicTimer implements \IteratorAggregate, \Countable
     /**
      * @param $name
      *
-     * @return bool
+     * @return TimerInterface|bool
      */
     public function getPeriodicTimer($name)
     {
@@ -78,11 +79,7 @@ class ConnectionPeriodicTimer implements \IteratorAggregate, \Countable
     {
         $tid = $this->getTid($name);
 
-        if (!isset($this->registry[$tid])) {
-            return false;
-        }
-
-        return $this->loop->isTimerActive($this->registry[$tid]);
+        return isset($this->registry[$tid]);
     }
 
     /**
@@ -110,7 +107,7 @@ class ConnectionPeriodicTimer implements \IteratorAggregate, \Countable
     }
 
     /**
-     * return int.
+     * return int
      */
     public function count()
     {

--- a/Topic/TopicPeriodicTimer.php
+++ b/Topic/TopicPeriodicTimer.php
@@ -2,16 +2,15 @@
 
 namespace Gos\Bundle\WebSocketBundle\Topic;
 
-use Ratchet\ConnectionInterface;
-use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
 
 class TopicPeriodicTimer implements \IteratorAggregate
 {
     /**
-     * @var array
+     * @var TimerInterface[]
      */
-    protected $registry;
+    protected $registry = [];
 
     /**
      * @var LoopInterface
@@ -19,13 +18,11 @@ class TopicPeriodicTimer implements \IteratorAggregate
     protected $loop;
 
     /**
-     * @param ConnectionInterface $connection
-     * @param LoopInterface       $loop
+     * @param LoopInterface $loop
      */
     public function __construct(LoopInterface $loop)
     {
         $this->loop = $loop;
-        $this->registry = [];
     }
 
     /**
@@ -48,7 +45,7 @@ class TopicPeriodicTimer implements \IteratorAggregate
     /**
      * @param TopicInterface $topic
      *
-     * @return array
+     * @return TimerInterface[]
      */
     public function getPeriodicTimers(TopicInterface $topic)
     {
@@ -100,11 +97,7 @@ class TopicPeriodicTimer implements \IteratorAggregate
     {
         $namespace = spl_object_hash($topic);
 
-        if (!isset($this->registry[$namespace][$name])) {
-            return false;
-        }
-
-        return $this->loop->isTimerActive($this->registry[$namespace][$name]);
+        return isset($this->registry[$namespace][$name]);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "symfony/framework-bundle": "^2.3|^3.0|^4.0",
         "gos/pubsub-router-bundle": "^0.3",
         "gos/websocket-client": "^0.1",
-        "gos/pnctl-event-loop-emitter" : "^0.1",
         "ocramius/proxy-manager": "^1.0|^2.1",
         "cboden/ratchet": "^0.4.1",
         "react/event-loop": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "gos/websocket-client": "^0.1",
         "gos/pnctl-event-loop-emitter" : "^0.1",
         "ocramius/proxy-manager": "^1.0|^2.1",
-        "cboden/ratchet": "^0.4.1"
+        "cboden/ratchet": "^0.4.1",
+        "react/event-loop": "^0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "gos/pnctl-event-loop-emitter" : "^0.1",
         "ocramius/proxy-manager": "^1.0|^2.1",
         "cboden/ratchet": "^0.4.1",
-        "react/event-loop": "^0.5"
+        "react/event-loop": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
There were a few B/C breaks in the react/event-loop 0.5 release affecting this bundle.  They are accounted for with this PR.