### PR TITLE
[1.x] Deprecate using the config to add services to RPC, topic, server, and periodic registries in favor of service tagging and compiler passes

### DIFF
--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -103,6 +103,11 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
 
         //rpc
         if (!empty($configs['rpc'])) {
+            @trigger_error(
+                'Configuring RPC handlers with the `gos_web_socket.rpc` config node is deprecated and will be removed in 2.0. Add the `gos_web_socket.rpc` tag to your service definitions instead.',
+                E_USER_DEPRECATED
+            );
+
             $def = $container->getDefinition('gos_web_socket.rpc.registry');
 
             foreach ($configs['rpc'] as $rpc) {
@@ -114,6 +119,11 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
 
         //topic
         if (!empty($configs['topics'])) {
+            @trigger_error(
+                'Configuring topic handlers with the `gos_web_socket.topics` config node is deprecated and will be removed in 2.0. Add the `gos_web_socket.topic` tag to your service definitions instead.',
+                E_USER_DEPRECATED
+            );
+
             $def = $container->getDefinition('gos_web_socket.topic.registry');
 
             foreach ($configs['topics'] as $topic) {
@@ -125,6 +135,11 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
 
         //periodic
         if (!empty($configs['periodic'])) {
+            @trigger_error(
+                'Configuring periodic handlers with the `gos_web_socket.periodic` config node is deprecated and will be removed in 2.0. Add the `gos_web_socket.periodic` tag to your service definitions instead.',
+                E_USER_DEPRECATED
+            );
+
             $def = $container->getDefinition('gos_web_socket.periodic.registry');
 
             foreach ($configs['periodic'] as $periodic) {
@@ -136,6 +151,11 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
 
         //server
         if (!empty($configs['servers'])) {
+            @trigger_error(
+                'Configuring servers with the `gos_web_socket.servers` config node is deprecated and will be removed in 2.0. Add the `gos_web_socket.server` tag to your service definitions instead.',
+                E_USER_DEPRECATED
+            );
+
             $def = $container->getDefinition('gos_web_socket.server.registry');
 
             foreach ($configs['servers'] as $server) {
@@ -154,7 +174,7 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
             $container->getDefinition('gos_web_socket.router.wamp')
                 ->replaceArgument(0, new Reference('gos_pubsub_router.websocket'));
         }
-        
+
         // WAMP Pusher Configuration
         if (isset($configs['pushers']) && isset($configs['pushers']['wamp'])) {
             if (!is_bool($configs['pushers']['wamp']['ssl'])) {


### PR DESCRIPTION
With 2.0 [requiring Symfony 3.4 or later](https://github.com/GeniusesOfSymfony/WebSocketBundle/pull/348), the bundle's configuration can take advantage of auto configuring services for improved DX and that makes allowing the configuration of these service types through both the bundle's configuration tree and through service tags redundant.  Therefore, this PR deprecates these configuration nodes on the 1.x branch to be removed in 2.0.