### PR TITLE
[2.0] Refactor client storage to save the token from the session versus the user it represents

### DIFF
--- a/Client/ClientManipulatorInterface.php
+++ b/Client/ClientManipulatorInterface.php
@@ -4,22 +4,29 @@ namespace Gos\Bundle\WebSocketBundle\Client;
 
 use Ratchet\ConnectionInterface;
 use Ratchet\Wamp\Topic;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 interface ClientManipulatorInterface
 {
     /**
      * @param ConnectionInterface $connection
      *
-     * @return bool|string|UserInterface
+     * @return TokenInterface
      */
-    public function getClient(ConnectionInterface $connection);
+    public function getClient(ConnectionInterface $connection): TokenInterface;
+
+    /**
+     * @param ConnectionInterface $connection
+     *
+     * @return string|object
+     */
+    public function getUser(ConnectionInterface $connection);
 
     /**
      * @param Topic  $topic
      * @param string $username
      *
-     * @return array|bool
+     * @return TokenInterface[]|bool
      */
     public function findByUsername(Topic $topic, $username);
 
@@ -27,15 +34,15 @@ interface ClientManipulatorInterface
      * @param Topic $topic
      * @param array $roles
      *
-     * @return array|bool
+     * @return TokenInterface[]
      */
-    public function findByRoles(Topic $topic, array $roles);
+    public function findByRoles(Topic $topic, array $roles): array;
 
     /**
      * @param Topic $topic
      * @param bool  $anonymous
      *
-     * @return array|bool
+     * @return TokenInterface[]
      */
-    public function getAll(Topic $topic, $anonymous = false);
+    public function getAll(Topic $topic, $anonymous = false): array;
 }

--- a/Client/ClientStorageInterface.php
+++ b/Client/ClientStorageInterface.php
@@ -5,7 +5,7 @@ namespace Gos\Bundle\WebSocketBundle\Client;
 use Gos\Bundle\WebSocketBundle\Client\Driver\DriverInterface;
 use Gos\Bundle\WebSocketBundle\Client\Exception\StorageException;
 use Ratchet\ConnectionInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 interface ClientStorageInterface
 {
@@ -17,11 +17,11 @@ interface ClientStorageInterface
     /**
      * @param string $identifier
      *
-     * @return string|UserInterface|false
+     * @return TokenInterface
      *
      * @throws StorageException
      */
-    public function getClient($identifier);
+    public function getClient($identifier): TokenInterface;
 
     /**
      * @param ConnectionInterface $conn
@@ -31,12 +31,12 @@ interface ClientStorageInterface
     public function getStorageId(ConnectionInterface $conn);
 
     /**
-     * @param string               $identifier
-     * @param string|UserInterface $user
+     * @param string         $identifier
+     * @param TokenInterface $token
      *
      * @throws StorageException
      */
-    public function addClient($identifier, $user);
+    public function addClient($identifier, TokenInterface $token);
 
     /**
      * @param string $identifier

--- a/Event/ClientEventListener.php
+++ b/Event/ClientEventListener.php
@@ -8,7 +8,6 @@ use Gos\Bundle\WebSocketBundle\Client\Exception\ClientNotFoundException;
 use Gos\Bundle\WebSocketBundle\Client\Exception\StorageException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @author Johann Saunier <johann_27@hotmail.fr>
@@ -23,7 +22,7 @@ class ClientEventListener implements LoggerAwareInterface
     protected $clientStorage;
 
     /**
-     * @var WebsocketAuthenticationProvider
+     * @var WebsocketAuthenticationProviderInterface
      */
     protected $authenticationProvider;
 
@@ -51,13 +50,11 @@ class ClientEventListener implements LoggerAwareInterface
         ];
 
         try {
-            $user = $this->clientStorage->getClient($conn->WAMP->clientStorageId);
+            $token = $this->clientStorage->getClient($conn->WAMP->clientStorageId);
 
             $this->clientStorage->removeClient($conn->resourceId);
 
-            $username = $user instanceof UserInterface
-                ? $user->getUsername()
-                : $user;
+            $username = $token->getUsername();
 
             if ($this->logger) {
                 $this->logger->info(
@@ -107,7 +104,9 @@ class ClientEventListener implements LoggerAwareInterface
         ];
 
         if ($this->clientStorage->hasClient($conn->resourceId)) {
-            $loggerContext['client'] = $this->clientStorage->getClient($conn->WAMP->clientStorageId);
+            $token = $this->clientStorage->getClient($conn->WAMP->clientStorageId);
+
+            $loggerContext['client'] = $token->getUsername();
         }
 
         $this->logger->error(

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -213,9 +213,8 @@ services:
         class: Gos\Bundle\WebSocketBundle\Client\Auth\WebsocketAuthenticationProvider
         public: false
         arguments:
-            - '@security.token_storage'
-            - '%gos_web_socket.firewall%'
             - '@gos_web_socket.client_storage'
+            - '%gos_web_socket.firewall%'
         calls:
             - [ setLogger, ['@?monolog.logger.websocket'] ]
 

--- a/Resources/docs/SessionSetup.md
+++ b/Resources/docs/SessionSetup.md
@@ -286,6 +286,9 @@ use Ratchet\Wamp\Topic;
 
 class AcmeTopic implements TopicInterface
 {
+    /**
+     * @var ClientManipulatorInterface
+     */
     protected $clientManipulator;
 
     /**
@@ -302,7 +305,7 @@ class AcmeTopic implements TopicInterface
      */
     public function onSubscribe(ConnectionInterface $connection, Topic $topic, WampRequest $request)
     {
-        $user = $this->clientManipulator->getClient($connection);
+        $user = $this->clientManipulator->getUser($connection);
     }
 }
 ```
@@ -319,7 +322,10 @@ use Ratchet\Wamp\Topic;
 
 class AcmeTopic implements TopicInterface
 {
-    /**    protected $clientManipulator;
+    /**
+     * @var ClientManipulatorInterface
+     */
+    protected $clientManipulator;
 
     /**
      * @param ClientManipulatorInterface $clientManipulator
@@ -335,9 +341,9 @@ class AcmeTopic implements TopicInterface
      */
     public function onSubscribe(ConnectionInterface $connection, Topic $topic, WampRequest $request)
     {
-        $user1 = $this->clientManipulator->findByUsername($topic, 'user1');
-        if (false !== $user1) {
-            $topic->broadcast('message', array(), array($user1['connection']->WAMP->sessionId));
+        $userConnection = $this->clientManipulator->findByUsername($topic, 'user1');
+        if (false !== $userConnection) {
+            $topic->broadcast('message', array(), array($userConnection['connection']->WAMP->sessionId));
         }
     }
 }

--- a/Tests/Client/Auth/WebsocketAuthenticationProviderTest.php
+++ b/Tests/Client/Auth/WebsocketAuthenticationProviderTest.php
@@ -8,17 +8,11 @@ use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class WebsocketAuthenticationProviderTest extends TestCase
 {
     private const FIREWALLS = ['main'];
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|TokenStorageInterface
-     */
-    private $tokenStorage;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|ClientStorageInterface
@@ -34,12 +28,9 @@ class WebsocketAuthenticationProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
         $this->clientStorage = $this->createMock(ClientStorageInterface::class);
 
-        $this->provider = new WebsocketAuthenticationProvider(
-            $this->tokenStorage, self::FIREWALLS, $this->clientStorage
-        );
+        $this->provider = new WebsocketAuthenticationProvider($this->clientStorage, self::FIREWALLS);
     }
 
     public function testAnAnonymousTokenIsCreatedAndAddedToStorageWhenAGuestUserConnects()
@@ -56,13 +47,6 @@ class WebsocketAuthenticationProviderTest extends TestCase
         $connection->WAMP = (object) [
             'sessionId' => 'test',
         ];
-
-        $this->tokenStorage->expects($this->once())
-            ->method('getToken')
-            ->willReturn(null);
-
-        $this->tokenStorage->expects($this->once())
-            ->method('setToken');
 
         $clientIdentifier = 42;
 
@@ -92,13 +76,6 @@ class WebsocketAuthenticationProviderTest extends TestCase
         $connection->WAMP = (object) [
             'sessionId' => 'test',
         ];
-
-        $this->tokenStorage->expects($this->once())
-            ->method('getToken')
-            ->willReturn($token);
-
-        $this->tokenStorage->expects($this->once())
-            ->method('setToken');
 
         $clientIdentifier = 42;
 

--- a/Tests/Event/ClientEventListenerTest.php
+++ b/Tests/Event/ClientEventListenerTest.php
@@ -15,7 +15,6 @@ use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 class ClientEventListenerTest extends TestCase
 {
@@ -70,8 +69,8 @@ class ClientEventListenerTest extends TestCase
             'clientStorageId' => 'client_storage'
         ];
 
-        $user = $this->createMock(UserInterface::class);
-        $user->expects($this->once())
+        $token = $this->createMock(TokenInterface::class);
+        $token->expects($this->once())
             ->method('getUsername')
             ->willReturn('username');
 
@@ -83,7 +82,7 @@ class ClientEventListenerTest extends TestCase
         $this->clientStorage->expects($this->once())
             ->method('getClient')
             ->with($connection->WAMP->clientStorageId)
-            ->willReturn($user);
+            ->willReturn($token);
 
         $this->clientStorage->expects($this->once())
             ->method('removeClient')
@@ -215,7 +214,7 @@ class ClientEventListenerTest extends TestCase
         $this->clientStorage->expects($this->once())
             ->method('getClient')
             ->with($connection->WAMP->clientStorageId)
-            ->willReturn($this->createMock(UserInterface::class));
+            ->willReturn($this->createMock(TokenInterface::class));
 
         $this->clientStorage->expects($this->never())
             ->method('removeClient');

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -13,6 +13,15 @@
 - The `Gos\Bundle\WebSocketBundle\Event\ServerEvent` now requires a third argument, `$profile`, indicating if profiling is enabled (i.e. the `--profile` option from the `gos:websocket:server` command)
 - `Gos\Bundle\WebSocketBundle\Pusher\PusherInterface` now includes a `setName()` method
 - `Gos\Bundle\WebSocketBundle\Pusher\PusherRegistry::addPusher()` and `Gos\Bundle\WebSocketBundle\Pusher\ServerPushHandlerRegistry::addPushHandler()` no longer have a separate `$name` argument, the name from the injected object is used instead
+- `Gos\Bundle\WebSocketBundle\Client\ClientManipulatorInterface` has had several changes:
+    - The `getClient()` method now returns a `Symfony\Component\Security\Core\Authentication\Token\TokenInterface` object and the return is typehinted (`public function getClient(ConnectionInterface $connection): TokenInterface`)
+    - Added a `getUser()` method which is fundamentally similar to the behavior of `getClient()` in 1.x, essentially this is a shortcut for `$manipulator->getClient()->getUser();`
+    - Because of the change to `getClient()`, the return types of `findByUsername()`, `findByRoles()`, and `getAll()` have changed to `TokenInterface` objects
+    - `findByRoles()` and `getAll()` will now return an empty array when no matching objects are found instead of boolean false
+- `Gos\Bundle\WebSocketBundle\Client\ClientStorageInterface` has had the following changes:
+    - The `getClient()` method now returns a `Symfony\Component\Security\Core\Authentication\Token\TokenInterface` object and the return is typehinted (`public function getClient(ConnectionInterface $connection): TokenInterface`)
+    - The second argument of `addClient()` is now required to be a `TokenInterface` object
+    - `findByRoles()` and `getAll()` will now return an empty array when no matching objects are found instead of boolean false
 - All bundle services have been explicitly marked public or private
 - Registering periodic timers and push handlers in the default websocket server (`Gos\Bundle\WebSocketBundle\Server\Type\WebSocketServer`) has been extracted to event listeners subscribed to the `gos_web_socket.server_launched` event
 


### PR DESCRIPTION
This changes the client storage layer to store the `Symfony\Component\Security\Core\Authentication\Token\TokenInterface` object that is read out of the session when processing a client connection versus storing whatever user implementation the token is wrapping.  This also has a couple of other mild UX tweaks.

### Storage Layer Changes

The `WebsocketAuthenticationProvider` right now authenticates a token then replaces whatever token is in the `@security.token_storage` service.  With the websocket server being a single long running backend process, this is woefully inefficient and can cause some unexpected behavior if you try to use the `@security.authorization_checker` service for any type of access checks (i.e. if your topic implements `Gos\Bundle\WebSocketBundle\Topic\SecuredTopicInterface`).  So it has been changed to no longer use the `@security.token_storage` service.  Since I removed the token storage, I also fixed the constructor so it no longer had the optional firewalls array before the required client storage.

The `ClientManipulatorInterface` has the following changes:

- `getClient()` now returns a `Symfony\Component\Security\Core\Authentication\Token\TokenInterface` object instead of a mixed return representing a user
- There is a new `getUser()` method, which is in essence a shortcut for `$clientManipulator->getClient()->getUser()` (note the return docblock here matches the `TokenInterface::getUser()` docblock and purposefully does not typehint a `Symfony\Component\Security\Core\User\UserInterface` object)
- The returns of `findByUsername()`, `findByRoles()` and `getAll()` are impacted by the storage change, the Token will be returned instead of the user representation (string/object/whatever)
- `findByRoles()` and `getAll()` now only return arrays, including for when no matching users/tokens are found, these returns are enforced with scalar typehinting

All of the relevant changes can be seen in the concrete `ClientManipulator` implementation.

The `ClientStorageInterface` has the following changes:

- `getClient()` now returns a `Symfony\Component\Security\Core\Authentication\Token\TokenInterface` object instead of a mixed return representing a user
- The second argument of `addClient()` is now required to be a `Symfony\Component\Security\Core\Authentication\Token\TokenInterface` object

### B/C Impacts

The worst changes are going to be in services using the `ClientManipulatorInterface` as that is the [documented way to fetch a user](https://github.com/GeniusesOfSymfony/WebSocketBundle/blob/95ee869ab282470e31696e793cfaccfd7d5e846c/Resources/docs/SessionSetup.md#retrieve-authenticated-user) for the current task (RPC or Topic).  As the `ClientStorageInterface` is a bit more of an internal detail behind the manipulator, the changes here should be less problematic unless you have your own manipulator and/or storage classes.