### PR TITLE
[2.0] Enable support for the WsServer keepalive feature

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,6 +15,8 @@ class Configuration implements ConfigurationInterface
     private const DEFAULT_CLIENT_STORAGE_SERVICE = '@gos_web_socket.server.in_memory.client_storage.driver';
     private const DEFAULT_FIREWALL = 'ws_firewall';
     private const DEFAULT_ORIGIN_CHECKER = false;
+    private const DEFAULT_KEEPALIVE_PING = false;
+    private const DEFAULT_KEEPALIVE_INTERVAL = 30;
     public const DEFAULT_TOKEN_SEPARATOR = '/';
     public const PING_SERVICE_TYPE_DOCTRINE = 'doctrine';
     public const PING_SERVICE_TYPE_PDO = 'pdo';
@@ -81,6 +83,16 @@ class Configuration implements ConfigurationInterface
                     ->booleanNode('origin_check')
                         ->defaultValue(static::DEFAULT_ORIGIN_CHECKER)
                         ->example(true)
+                    ->end()
+                    ->booleanNode('keepalive_ping')
+                        ->defaultValue(static::DEFAULT_KEEPALIVE_PING)
+                        ->example(true)
+                        ->info('Flag indicating a keepalive ping should be enabled on the server')
+                    ->end()
+                    ->integerNode('keepalive_interval')
+                        ->defaultValue(static::DEFAULT_KEEPALIVE_INTERVAL)
+                        ->example(30)
+                        ->info('The time in seconds between each keepalive ping')
                     ->end()
                     ->arrayNode('router')
                         ->children()

--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -56,6 +56,14 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
                 $container->setParameter('web_socket_origin_check', $configs['server']['origin_check']);
             }
 
+            if (isset($configs['server']['keepalive_ping'])) {
+                $container->setParameter('web_socket_keepalive_ping', $configs['server']['keepalive_ping']);
+            }
+
+            if (isset($configs['server']['keepalive_interval'])) {
+                $container->setParameter('web_socket_keepalive_interval', $configs['server']['keepalive_interval']);
+            }
+
             $pubsubConfig = $configs['server']['router'] ?? [];
 
             // The router was configured through the prepend pass, we only need to change the router the WampRouter uses

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -46,6 +46,8 @@ services:
             - '@gos_web_socket.origins.registry'
             - '@event_dispatcher'
             - '%web_socket_origin_check%'
+            - '%web_socket_keepalive_ping%'
+            - '%web_socket_keepalive_interval%'
 
     gos_web_socket.server.registry:
         class: Gos\Bundle\WebSocketBundle\Server\App\Registry\ServerRegistry

--- a/Server/App/ServerBuilder.php
+++ b/Server/App/ServerBuilder.php
@@ -50,6 +50,16 @@ final class ServerBuilder
     private $originCheck = false;
 
     /**
+     * @var bool
+     */
+    private $keepalivePing = false;
+
+    /**
+     * @var int
+     */
+    private $keepaliveInterval = 30;
+
+    /**
      * @var \SessionHandlerInterface|null
      */
     private $sessionHandler;
@@ -60,7 +70,9 @@ final class ServerBuilder
         TopicManager $topicManager,
         OriginRegistry $originRegistry,
         EventDispatcherInterface $eventDispatcher,
-        bool $originCheck
+        bool $originCheck,
+        bool $keepalivePing,
+        int $keepaliveInterval
     ) {
         $this->loop = $loop;
         $this->wampApplication = $wampApplication;
@@ -68,6 +80,8 @@ final class ServerBuilder
         $this->originRegistry = $originRegistry;
         $this->eventDispatcher = $eventDispatcher;
         $this->originCheck = $originCheck;
+        $this->keepalivePing = $keepalivePing;
+        $this->keepaliveInterval = $keepaliveInterval;
     }
 
     public function buildMessageStack(): MessageComponentInterface
@@ -79,6 +93,10 @@ final class ServerBuilder
             )
         );
         $serverComponent->setStrictSubProtocolCheck(false);
+
+        if ($this->keepalivePing) {
+            $serverComponent->enableKeepAlive($this->loop, $this->keepaliveInterval);
+        }
 
         if ($this->sessionHandler) {
             $serverComponent = new SessionProvider(

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -23,6 +23,8 @@ final class ConfigurationTest extends TestCase
                 'host' => '127.0.0.1',
                 'port' => 8080,
                 'origin_check' => false,
+                'keepalive_ping' => false,
+                'keepalive_interval' => 30,
             ],
         ];
 
@@ -42,6 +44,8 @@ final class ConfigurationTest extends TestCase
                 'host' => '127.0.0.1',
                 'port' => 8080,
                 'origin_check' => false,
+                'keepalive_ping' => false,
+                'keepalive_interval' => 30,
                 'router' => [
                     'resources' => [
                         'example.yaml',

--- a/Tests/Server/App/ServerBuilderTest.php
+++ b/Tests/Server/App/ServerBuilderTest.php
@@ -62,7 +62,9 @@ class ServerBuilderTest extends TestCase
             $this->topicManager,
             $this->originRegistry,
             $this->eventDispatcher,
-            false
+            false,
+            false,
+            30
         );
     }
 
@@ -120,7 +122,9 @@ class ServerBuilderTest extends TestCase
             $this->topicManager,
             $this->originRegistry,
             $this->eventDispatcher,
-            true
+            true,
+            false,
+            30
         );
 
         $server = $builder->buildMessageStack();


### PR DESCRIPTION
In Ratchet 0.4, support was added for a keepalive function in the `WsServer` class.  This PR adds support for enabling it through the bundle config.  Added is:

- A new configuration node to enable the keepalive ping
- A new configuration node to specify the ping interval (in seconds)
- Relevant code in the server builder to enable the feature at runtime

To enable, update the bundle config:

```yaml
gos_web_socket:
    server:
        keepalive_ping: true
        keepalive_interval: 30 #time in seconds between pings, defaults to 30
```