### PR TITLE
[1.x] Deprecate support for the ZMQ pusher

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -327,6 +327,10 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end();
 
+        if (method_exists($node, 'setDeprecated')) {
+            $node->setDeprecated('The child node "%node%" at path "%path%" is deprecated. Support for ZMQ will be removed.');
+        }
+
         return $node;
     }
 

--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -5,6 +5,7 @@ namespace Gos\Bundle\WebSocketBundle\DependencyInjection;
 use Monolog\Logger;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
@@ -175,10 +176,31 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
                 ->replaceArgument(0, new Reference('gos_pubsub_router.websocket'));
         }
 
-        // WAMP Pusher Configuration
-        if (isset($configs['pushers']) && isset($configs['pushers']['wamp'])) {
-            if (!is_bool($configs['pushers']['wamp']['ssl'])) {
-                throw new \InvalidArgumentException(sprintf('The ssl node under wamp pusher configuration must be a boolean value'));
+        // Pusher Configuration
+        if (isset($configs['pushers'])) {
+            // Validate WAMP configuration
+            if (isset($configs['pushers']['wamp'])) {
+                if (!is_bool($configs['pushers']['wamp']['ssl'])) {
+                    throw new \InvalidArgumentException(
+                        sprintf('The ssl node under wamp pusher configuration must be a boolean value')
+                    );
+                }
+            }
+
+            // Deprecate ZMQ pusher
+            if (isset($configs['pushers']['zmq'])) {
+                @trigger_error(
+                    'Support for the ZMQ pusher is deprecated and will be removed in 2.0.',
+                    E_USER_DEPRECATED
+                );
+
+                if (method_exists(Definition::class, 'setDeprecated')) {
+                    $pusherDef = $container->getDefinition('gos_web_socket.zmq.pusher');
+                    $pusherDef->setDeprecated(true);
+
+                    $pushHandlerDef = $container->getDefinition('gos_web_socket.zmq.server_push_handler');
+                    $pushHandlerDef->setDeprecated(true);
+                }
             }
         }
     }

--- a/DependencyInjection/GosWebSocketExtension.php
+++ b/DependencyInjection/GosWebSocketExtension.php
@@ -40,6 +40,12 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
 
             $container->getDefinition('gos_web_socket.twig.extension')
                 ->setDeprecated(true, 'The "%service_id%" service is deprecated. Support for Assetic will be removed.');
+
+            $container->getDefinition('gos_web_socket.zmq.pusher')
+                ->setDeprecated(true, 'The "%service_id%" service is deprecated. Support for ZMQ as a pusher will be removed.');
+
+            $container->getDefinition('gos_web_socket.zmq.server_push_handler')
+                ->setDeprecated(true, 'The "%service_id%" service is deprecated. Support for ZMQ as a server push handler will be removed.');
         }
 
         // Set the SecurityContext for Symfony <2.6
@@ -203,14 +209,6 @@ class GosWebSocketExtension extends Extension implements PrependExtensionInterfa
                     'Support for the ZMQ pusher is deprecated and will be removed in 2.0.',
                     E_USER_DEPRECATED
                 );
-
-                if (method_exists(Definition::class, 'setDeprecated')) {
-                    $pusherDef = $container->getDefinition('gos_web_socket.zmq.pusher');
-                    $pusherDef->setDeprecated(true);
-
-                    $pushHandlerDef = $container->getDefinition('gos_web_socket.zmq.server_push_handler');
-                    $pushHandlerDef->setDeprecated(true);
-                }
             }
         }
     }

--- a/Pusher/Zmq/ZmqPusher.php
+++ b/Pusher/Zmq/ZmqPusher.php
@@ -4,6 +4,8 @@ namespace Gos\Bundle\WebSocketBundle\Pusher\Zmq;
 
 use Gos\Bundle\WebSocketBundle\Pusher\AbstractPusher;
 
+@trigger_error(sprintf('The %s class is deprecated will be removed in 2.0.', ZmqPusher::class), E_USER_DEPRECATED);
+
 class ZmqPusher extends AbstractPusher
 {
     /**

--- a/Pusher/Zmq/ZmqPusher.php
+++ b/Pusher/Zmq/ZmqPusher.php
@@ -6,6 +6,9 @@ use Gos\Bundle\WebSocketBundle\Pusher\AbstractPusher;
 
 @trigger_error(sprintf('The %s class is deprecated will be removed in 2.0.', ZmqPusher::class), E_USER_DEPRECATED);
 
+/**
+ * @deprecated to be removed in 2.0
+ */
 class ZmqPusher extends AbstractPusher
 {
     /**

--- a/Pusher/Zmq/ZmqServerPushHandler.php
+++ b/Pusher/Zmq/ZmqServerPushHandler.php
@@ -18,6 +18,8 @@ use React\ZMQ\SocketWrapper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Log\NullLogger;
 
+@trigger_error(sprintf('The %s class is deprecated will be removed in 2.0.', ZmqServerPushHandler::class), E_USER_DEPRECATED);
+
 class ZmqServerPushHandler extends AbstractServerPushHandler
 {
     /** @var PusherInterface  */

--- a/Pusher/Zmq/ZmqServerPushHandler.php
+++ b/Pusher/Zmq/ZmqServerPushHandler.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpKernel\Log\NullLogger;
 
 @trigger_error(sprintf('The %s class is deprecated will be removed in 2.0.', ZmqServerPushHandler::class), E_USER_DEPRECATED);
 
+/**
+ * @deprecated to be removed in 2.0
+ */
 class ZmqServerPushHandler extends AbstractServerPushHandler
 {
     /** @var PusherInterface  */

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -196,12 +196,14 @@ services:
             - [ setRouter, ['@gos_web_socket.router.wamp' ] ]
             - [ setSerializer, ['@gos_web_socket.push_message.serializer' ] ]
 
+    # Deprecated and will be removed in 2.0
     gos_web_socket.zmq.pusher:
         parent: gos_web_socket.abstract.pusher
         class: Gos\Bundle\WebSocketBundle\Pusher\Zmq\ZmqPusher
         tags:
             - { name: gos_web_socket.pusher, alias: zmq }
 
+    # Deprecated and will be removed in 2.0
     gos_web_socket.zmq.server_push_handler:
         class: Gos\Bundle\WebSocketBundle\Pusher\Zmq\ZmqServerPushHandler
         arguments:


### PR DESCRIPTION
It looks like the [`zmq`](https://github.com/mkoppanen/php-zmq) extension hasn't been touched since support for PHP 7.0 was added, it looks like the extension can be considered abandonware at this point.  So, this PR deprecates support for it, to be removed in 2.0.