### PR TITLE
Fix some AMQP issues

### DIFF
--- a/Pusher/Amqp/AmqpPusher.php
+++ b/Pusher/Amqp/AmqpPusher.php
@@ -39,9 +39,10 @@ final class AmqpPusher extends AbstractPusher
     {
         if (false === $this->connected) {
             $this->connection = $this->connectionFactory->createConnection();
+            $this->connection->connect();
+
             $this->exchange = $this->connectionFactory->createExchange($this->connection);
 
-            $this->connection->connect();
             $this->setConnected();
         }
 

--- a/Pusher/Amqp/AmqpPusher.php
+++ b/Pusher/Amqp/AmqpPusher.php
@@ -50,7 +50,7 @@ final class AmqpPusher extends AbstractPusher
 
         $resolver->setDefaults(
             [
-                'routing_key' => null,
+                'routing_key' => '',
                 'publish_flags' => AMQP_NOPARAM,
                 'attributes' => [],
             ]


### PR DESCRIPTION
This PR fixes two issues with the AMQP pusher I ran into when updating to latest version, both happening when trying to use the pusher.

> Could not create channel. No connection available.

The exchange was being created before establishing the connection 

> AMQPExchange::publish() expects parameter 2 to be string, null given

I changed the default routing key from `null` to an empty string since it seems that the `\AMQPExchange::publish` method signature has explicit type hints with php 7. 
