### PR TITLE
Periodic timer becomes broken when all topic subscribers closed their connections

### DIFF
--- a/src/Topic/TopicManager.php
+++ b/src/Topic/TopicManager.php
@@ -90,6 +90,7 @@ class TopicManager implements WsServerInterface, WampServerInterface
 
         foreach ($this->topicLookup as $topic) {
             $this->cleanTopic($topic, $conn);
+            $this->app->onUnsubscribe($conn, $topic);
         }
     }
 


### PR DESCRIPTION
Steps to reproduce:
1 Create and register a topic with TopicPeriodicTimerInterface
2 Connect to webscoket server and subscribe to this periodic topic (make sure you are the only one subscriber)
3 Close the connection with websocket server (not unsubscribe, but just close)
4 Connect to websocket server again and subscriber to periodic topic

Actual result: periodic messages are not received by new subscriber
Expected result:  periodic messages are sent and received by new subscriber

Reason: topic with 0 subscribers is not removed from periodic timers registry, but removed from `TopicManager::$topicLookup` which prevents periodic timer to be registered for new topic object when a new subscriber connects.

Possible solution: call `TopicManager::onUnsubscriber()` for each subscribed topic when connection is closed, so each topic and TopicDispatcher can correctly handle subscriber disconnection.