### PR TITLE
Change used id for sending just to one client

### DIFF
--- a/docs/topics.md
+++ b/docs/topics.md
@@ -289,7 +289,7 @@ class AcmeConnectionPeriodicTopic extends AcmeTopic
             300,
             function () use ($connection, $topic) {
                 // Broadcasts only to the current user
-                $topic->broadcast('hello world', [], [$connection->resourceId]);
+                $topic->broadcast('hello world', [], [$connection->WAMP->sessionId]);
             }
         );
     }


### PR DESCRIPTION
**What actually happens**
It does not send the messages while using the id showed in the sample.

**How to reproduce**
Just run an app which uses the sample code from your docs and try to send the message to just one client - the one which has been connected to topic.

**The remediation**
Just use `$connection->WAMP->sessionId` instead.